### PR TITLE
fix: car creation toast/redirect, sidebar refresh, license plate form…

### DIFF
--- a/src/app/features/cars/cars.utils.ts
+++ b/src/app/features/cars/cars.utils.ts
@@ -29,3 +29,10 @@ export function formatMileage(val: number | null | undefined): string {
     if (val == null) return '—';
     return Number(val).toLocaleString() + ' km';
 }
+
+export function formatLicensePlate(value: string | null | undefined): string {
+    if (!value) return '';
+    const cleaned = value.toUpperCase().replace(/[^A-Z0-9]/g, '');
+    const groups = cleaned.match(/[A-Z]+|[0-9]+/g) ?? [];
+    return groups.join(' ');
+}

--- a/src/app/features/cars/component/cars-form/cars-form.component.ts
+++ b/src/app/features/cars/component/cars-form/cars-form.component.ts
@@ -1,6 +1,6 @@
 import {Component, Input, OnInit, Signal} from '@angular/core';
 import {toSignal} from '@angular/core/rxjs-interop';
-import {FormBuilder, FormGroup, ReactiveFormsModule} from '@angular/forms';
+import {FormBuilder, FormControl, FormGroup, ReactiveFormsModule} from '@angular/forms';
 import {AddCarDto, CarDto} from '@hau/autogenapi/models';
 import {CarDetailsFacade} from '@hau/features/cars/state/car-details/car-details.facade';
 import {FormControlType, FormFieldComponent, InputType} from '@hau/shared/component/form-field/form-field.component';
@@ -17,7 +17,7 @@ import {
   MIN_YEAR_CAR_CREATE,
   TRANSMISSION_OPTIONS
 } from '@hau/features/cars/cars.constants';
-import {daysUntil, formatDate, formatMileage, removeNullProperties} from '@hau/features/cars/cars.utils';
+import {daysUntil, formatDate, formatLicensePlate, formatMileage, removeNullProperties} from '@hau/features/cars/cars.utils';
 import {addIcons} from 'ionicons';
 import {
   addCircleOutline,
@@ -41,6 +41,17 @@ import {ImageUrlPipe} from '@hau/shared/pipes/image-url.pipe';
 type ExistingPhoto = { kind: 'existing'; id: number; url: string; isDefault: boolean };
 type NewPhoto      = { kind: 'new'; file: File; url: string; isDefault: boolean };
 type PhotoEntry    = ExistingPhoto | NewPhoto;
+
+/**
+ * Formats the license plate (uppercase, grouped by letters/digits) at the single
+ * point where its value is set, so the live input, programmatic patches and the
+ * form-field's internal re-sync subscription all converge on the same formatted value.
+ */
+class LicensePlateControl extends FormControl<string | null> {
+  override setValue(value: string | null, options?: Parameters<FormControl<string | null>['setValue']>[1]): void {
+    super.setValue(value ? formatLicensePlate(value) : value, options);
+  }
+}
 
 @UntilDestroy()
 @Component({
@@ -106,7 +117,7 @@ export class CarsFormComponent implements OnInit {
       make: null,
       model: null,
       variant: null,
-      license_plate: null,
+      license_plate: new LicensePlateControl(null),
       nickname: null,
       vin: null,
       year: null,

--- a/src/app/features/cars/state/car-details/car-details.state.ts
+++ b/src/app/features/cars/state/car-details/car-details.state.ts
@@ -4,7 +4,7 @@ import { AddCarDto, CarDto, DocumentDto, MaintenanceRecordDto } from '@hau/autog
 import { CarService, DocumentService, MaintenanceRecordService } from '@hau/autogenapi/services';
 import { CarDetailsActions } from '@hau/features/cars/state/car-details/car-details.actions';
 import { CarListActions } from '@hau/features/cars/state/car-list/car-list.actions';
-import { NavController, ToastController } from '@ionic/angular';
+import { NavController, ToastController } from '@ionic/angular/standalone';
 import { Action, Selector, State, StateContext } from '@ngxs/store';
 import { take } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';

--- a/src/app/features/main/main.component.ts
+++ b/src/app/features/main/main.component.ts
@@ -83,11 +83,11 @@ export class MainComponent implements OnInit {
       .subscribe(() => {
         this.currentPath = this.router.url;
         this.selectedMenuItem = this.resolveActiveMenuItem(this.currentPath);
+        this.loadSidebarData();
       });
   }
 
   ngOnInit(): void {
-    this.loadSidebarData();
     this.versionService.check();
   }
 


### PR DESCRIPTION
…atting

ToastController/NavController were imported from the non-standalone @ionic/angular bundle, which never registers <ion-toast> as a custom element — toast.present() threw and silently aborted createCarSuccess before it could navigate to the car list. Switched the import to @ionic/angular/standalone so the success toast shows and the redirect happens.

Sidebar vehicle counts were only loaded once at bootstrap; moved the refresh into the existing NavigationEnd subscription so they stay in sync after CRUD operations (e.g. right after adding a car).

License plate input now auto-uppercases and groups letters/digits with spaces in real time (bv99hau -> BV 99 HAU), formatted at the FormControl level so it converges correctly with the form-field's internal value sync.