### PR TITLE
Route all hardcoded UI text through Transloco, add full RO translations

### DIFF
--- a/src/app/core/transloco/transloco-http-loader.service.ts
+++ b/src/app/core/transloco/transloco-http-loader.service.ts
@@ -3,10 +3,17 @@ import { Injectable } from '@angular/core';
 import { Translation, TranslocoLoader, TranslocoService } from '@ngneat/transloco';
 import { Observable, firstValueFrom } from 'rxjs';
 
+export const LANGUAGE_STORAGE_KEY = 'hau-lang';
+
+export function getStoredLang(): string {
+  return localStorage.getItem(LANGUAGE_STORAGE_KEY) ?? 'en';
+}
+
 export function preloadTranslation(transloco: TranslocoService): () => Promise<Translation> {
   return () => {
-    transloco.setActiveLang('en');
-    return firstValueFrom(transloco.load('en'));
+    const lang = getStoredLang();
+    transloco.setActiveLang(lang);
+    return firstValueFrom(transloco.load(lang));
   };
 }
 

--- a/src/app/features/auth/login/login.component.html
+++ b/src/app/features/auth/login/login.component.html
@@ -10,27 +10,26 @@
       </div>
       <div class="login-logo__text">
         <span class="login-logo__name">History Auto Utility</span>
-        <span class="login-logo__tagline">VEHICLE CARE MADE SIMPLE</span>
+        <span class="login-logo__tagline">{{ 'sidebar.slogan' | transloco }}</span>
       </div>
     </div>
 
     <!-- Trust badge -->
     <div class="login-trust-badge">
       <ion-icon name="shield-checkmark-outline"></ion-icon>
-      Trusted by vehicle owners
+      {{ 'login.trustBadge' | transloco }}
     </div>
 
     <!-- Hero -->
-    <h1 class="login-headline">Manage your vehicles<br>with confidence</h1>
+    <h1 class="login-headline" [innerHTML]="'login.headline' | transloco"></h1>
     <p class="login-hero-desc">
-      Track documents, maintenance, and important deadlines
-      so your vehicles stay road-ready and worry-free.
+      {{ 'login.heroDesc' | transloco }}
     </p>
 
     <!-- Login card -->
     <div class="login-card hau-card">
-      <h2 class="login-card__title">Welcome back</h2>
-      <p class="login-card__subtitle">Sign in securely with your Google account</p>
+      <h2 class="login-card__title">{{ 'login.card.title' | transloco }}</h2>
+      <p class="login-card__subtitle">{{ 'login.card.subtitle' | transloco }}</p>
 
       <button class="google-signin-btn" (click)="loginWithGoogle()">
         <svg class="google-g" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -39,16 +38,16 @@
           <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z" fill="#FBBC05"/>
           <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
         </svg>
-        Continue with Google
+        {{ 'login.card.googleButton' | transloco }}
       </button>
 
-      <div class="login-divider"><span>or</span></div>
+      <div class="login-divider"><span>{{ 'login.card.or' | transloco }}</span></div>
 
       <div class="login-privacy-note">
         <ion-icon name="lock-closed-outline" class="login-privacy-note__icon"></ion-icon>
         <div>
-          <p class="login-privacy-note__line">Secure, private, and easy to use.</p>
-          <p class="login-privacy-note__line login-privacy-note__line--muted">We never access or share your Google data.</p>
+          <p class="login-privacy-note__line">{{ 'login.card.privacyLine' | transloco }}</p>
+          <p class="login-privacy-note__line login-privacy-note__line--muted">{{ 'login.card.privacyLineMuted' | transloco }}</p>
         </div>
       </div>
     </div>
@@ -60,8 +59,8 @@
           <ion-icon name="shield-outline"></ion-icon>
         </div>
         <div>
-          <p class="login-feature__title">Your data stays private</p>
-          <p class="login-feature__desc">We respect your privacy and keep your data safe.</p>
+          <p class="login-feature__title">{{ 'login.features.privacy.title' | transloco }}</p>
+          <p class="login-feature__desc">{{ 'login.features.privacy.desc' | transloco }}</p>
         </div>
       </div>
       <div class="login-feature">
@@ -69,8 +68,8 @@
           <ion-icon name="lock-closed-outline"></ion-icon>
         </div>
         <div>
-          <p class="login-feature__title">Secure by design</p>
-          <p class="login-feature__desc">Enterprise-grade security to protect what matters.</p>
+          <p class="login-feature__title">{{ 'login.features.security.title' | transloco }}</p>
+          <p class="login-feature__desc">{{ 'login.features.security.desc' | transloco }}</p>
         </div>
       </div>
       <div class="login-feature">
@@ -78,18 +77,18 @@
           <ion-icon name="car-outline"></ion-icon>
         </div>
         <div>
-          <p class="login-feature__title">One account for all vehicles</p>
-          <p class="login-feature__desc">Access all your vehicles and data in one place.</p>
+          <p class="login-feature__title">{{ 'login.features.oneAccount.title' | transloco }}</p>
+          <p class="login-feature__desc">{{ 'login.features.oneAccount.desc' | transloco }}</p>
         </div>
       </div>
     </div>
 
     <!-- Footer -->
     <footer class="login-footer">
-      <span>© 2026 History Auto Utility. All rights reserved.</span>
+      <span>{{ 'login.footer.copyright' | transloco }}</span>
       <span class="login-footer__links">
-        <a href="#">Privacy Policy</a>
-        <a href="#">Terms of Service</a>
+        <a href="#">{{ 'login.footer.privacyPolicy' | transloco }}</a>
+        <a href="#">{{ 'login.footer.termsOfService' | transloco }}</a>
       </span>
     </footer>
 
@@ -105,9 +104,9 @@
           <ion-icon name="construct-outline"></ion-icon>
         </div>
         <div>
-          <p class="preview-float__meta">Upcoming service</p>
+          <p class="preview-float__meta">{{ 'overview.stats.upcomingService' | transloco }}</p>
           <p class="preview-float__value">1</p>
-          <p class="preview-float__sub">Next 30 days</p>
+          <p class="preview-float__sub">{{ 'overview.stats.upcomingServiceSub' | transloco }}</p>
         </div>
       </div>
 
@@ -119,75 +118,75 @@
             <div class="preview-brand__icon"><ion-icon name="car"></ion-icon></div>
             <div>
               <p class="preview-brand__name">History Auto Utility</p>
-              <p class="preview-brand__tag">VEHICLE CARE MADE SIMPLE</p>
+              <p class="preview-brand__tag">{{ 'sidebar.slogan' | transloco }}</p>
             </div>
           </div>
 
           <div class="preview-garage-card">
             <ion-icon name="home-outline"></ion-icon>
             <div>
-              <p class="preview-garage-card__title">My Garage</p>
-              <p class="preview-garage-card__count">3 vehicles</p>
+              <p class="preview-garage-card__title">{{ 'sidebar.myGarage' | transloco }}</p>
+              <p class="preview-garage-card__count">{{ 'login.preview.vehiclesCount' | transloco }}</p>
             </div>
             <ion-icon name="chevron-forward-outline" class="preview-garage-card__arrow"></ion-icon>
           </div>
 
-          <p class="preview-section-label">MAIN</p>
+          <p class="preview-section-label">{{ 'sidebar.mainSection' | transloco }}</p>
           <nav class="preview-nav">
             <div class="preview-nav__item preview-nav__item--active">
-              <ion-icon name="speedometer-outline"></ion-icon> Overview
+              <ion-icon name="speedometer-outline"></ion-icon> {{ 'sidebar.nav.overview' | transloco }}
             </div>
             <div class="preview-nav__item">
-              <ion-icon name="car-outline"></ion-icon> Garage
+              <ion-icon name="car-outline"></ion-icon> {{ 'sidebar.nav.garage' | transloco }}
             </div>
             <div class="preview-nav__item">
-              <ion-icon name="document-text-outline"></ion-icon> Documents
+              <ion-icon name="document-text-outline"></ion-icon> {{ 'sidebar.nav.documents' | transloco }}
             </div>
             <div class="preview-nav__item">
-              <ion-icon name="construct-outline"></ion-icon> Maintenance
+              <ion-icon name="construct-outline"></ion-icon> {{ 'sidebar.nav.maintenance' | transloco }}
             </div>
             <div class="preview-nav__item">
-              <ion-icon name="bar-chart-outline"></ion-icon> Reports
+              <ion-icon name="bar-chart-outline"></ion-icon> {{ 'sidebar.nav.reports' | transloco }}
             </div>
           </nav>
 
           <div class="preview-alert-card">
             <ion-icon name="warning-outline" class="preview-alert-card__icon"></ion-icon>
             <div>
-              <p class="preview-alert-card__title">Attention needed</p>
-              <p class="preview-alert-card__item">• 2 documents expire soon</p>
-              <p class="preview-alert-card__item">• Oil service in <strong>1,250 km</strong></p>
+              <p class="preview-alert-card__title">{{ 'sidebar.attention.title' | transloco }}</p>
+              <p class="preview-alert-card__item">• {{ 'login.preview.documentsExpireSoon' | transloco }}</p>
+              <p class="preview-alert-card__item">• <span [innerHTML]="'login.preview.oilServiceIn' | transloco"></span></p>
             </div>
           </div>
         </div>
 
         <!-- Overview panel -->
         <div class="preview-main">
-          <p class="preview-main__title">Overview</p>
-          <p class="preview-main__subtitle">Your fleet status at a glance</p>
+          <p class="preview-main__title">{{ 'sidebar.nav.overview' | transloco }}</p>
+          <p class="preview-main__subtitle">{{ 'overview.subtitle' | transloco }}</p>
 
           <div class="preview-stats-row">
             <div class="preview-stat-box">
               <ion-icon name="car-outline" class="preview-stat-box__icon preview-stat-box__icon--blue"></ion-icon>
               <p class="preview-stat-box__num">3</p>
-              <p class="preview-stat-box__label">Vehicles</p>
-              <p class="preview-stat-box__sub">Total in garage</p>
+              <p class="preview-stat-box__label">{{ 'overview.stats.vehicles' | transloco }}</p>
+              <p class="preview-stat-box__sub">{{ 'overview.stats.vehiclesSub' | transloco }}</p>
             </div>
             <div class="preview-stat-box">
               <ion-icon name="document-outline" class="preview-stat-box__icon preview-stat-box__icon--orange"></ion-icon>
               <p class="preview-stat-box__num">2</p>
-              <p class="preview-stat-box__label">Documents expiring</p>
-              <p class="preview-stat-box__sub">Needs attention</p>
+              <p class="preview-stat-box__label">{{ 'login.preview.stats.documentsExpiring' | transloco }}</p>
+              <p class="preview-stat-box__sub">{{ 'overview.stats.docsExpiringSub' | transloco }}</p>
             </div>
             <div class="preview-stat-box">
               <ion-icon name="warning-outline" class="preview-stat-box__icon preview-stat-box__icon--red"></ion-icon>
               <p class="preview-stat-box__num">3</p>
-              <p class="preview-stat-box__label">Active alerts</p>
-              <p class="preview-stat-box__sub">Requires action</p>
+              <p class="preview-stat-box__label">{{ 'overview.stats.alerts' | transloco }}</p>
+              <p class="preview-stat-box__sub">{{ 'overview.stats.alertsSub' | transloco }}</p>
             </div>
           </div>
 
-          <p class="preview-deadlines-label">Upcoming deadlines</p>
+          <p class="preview-deadlines-label">{{ 'overview.deadlines.title' | transloco }}</p>
           <div class="preview-vehicle-row">
             <div class="preview-vehicle-thumb"></div>
             <div class="preview-vehicle-info">
@@ -234,9 +233,9 @@
           <ion-icon name="shield-checkmark-outline"></ion-icon>
         </div>
         <div>
-          <p class="preview-float__meta">Documents updated</p>
-          <p class="preview-float__line">Insurance document</p>
-          <p class="preview-float__sub">Today, 10:24 AM</p>
+          <p class="preview-float__meta">{{ 'login.preview.documentsUpdated' | transloco }}</p>
+          <p class="preview-float__line">{{ 'login.preview.insuranceDocument' | transloco }}</p>
+          <p class="preview-float__sub">{{ 'login.preview.todayAt' | transloco }}</p>
         </div>
       </div>
 

--- a/src/app/features/auth/login/login.component.scss
+++ b/src/app/features/auth/login/login.component.scss
@@ -59,6 +59,7 @@
     font-size: 0.6rem;
     font-weight: 700;
     letter-spacing: 0.12em;
+    text-transform: uppercase;
     color: var(--hau-text-dim);
   }
 }
@@ -379,7 +380,7 @@
   }
 
   &__name { font-size: 0.65rem; font-weight: 700; color: var(--hau-text); margin: 0; line-height: 1.2; }
-  &__tag  { font-size: 0.5rem; font-weight: 700; letter-spacing: 0.08em; color: var(--hau-text-dim); margin: 0; }
+  &__tag  { font-size: 0.5rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--hau-text-dim); margin: 0; }
 }
 
 .preview-garage-card {
@@ -402,6 +403,7 @@
   font-size: 0.55rem;
   font-weight: 700;
   letter-spacing: 0.12em;
+  text-transform: uppercase;
   color: var(--hau-text-dim);
   margin: 0;
 }

--- a/src/app/features/auth/login/login.component.ts
+++ b/src/app/features/auth/login/login.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { AuthService } from '@hau/features/auth/auth.service';
 import { IonIcon } from '@ionic/angular/standalone';
+import { TranslocoPipe } from '@ngneat/transloco';
 import { addIcons } from 'ionicons';
 import {
   car, carOutline,
@@ -17,7 +18,7 @@ import {
     templateUrl: './login.component.html',
     styleUrls: ['./login.component.scss'],
     standalone: true,
-    imports: [IonIcon],
+    imports: [IonIcon, TranslocoPipe],
 })
 export class LoginComponent {
     constructor(private authService: AuthService) {

--- a/src/app/features/auth/token/token.component.html
+++ b/src/app/features/auth/token/token.component.html
@@ -1,3 +1,3 @@
 <p>
-  redirecting...
+  {{ 'app.redirecting' | transloco }}
 </p>

--- a/src/app/features/auth/token/token.component.ts
+++ b/src/app/features/auth/token/token.component.ts
@@ -1,5 +1,6 @@
 import {Component, OnInit} from '@angular/core';
 import {ActivatedRoute, Router} from '@angular/router';
+import {TranslocoPipe} from '@ngneat/transloco';
 import {AuthService} from '@hau/features/auth/auth.service';
 import {HAU_ROUTES} from '@hau/app.routes.const';
 
@@ -7,7 +8,8 @@ import {HAU_ROUTES} from '@hau/app.routes.const';
     selector: 'app-token',
     templateUrl: './token.component.html',
     styleUrls: ['./token.component.scss'],
-    standalone: true
+    standalone: true,
+    imports: [TranslocoPipe]
 })
 export class TokenComponent implements OnInit {
     constructor(

--- a/src/app/features/blog/blog-entry-view/blog-entry-view.component.html
+++ b/src/app/features/blog/blog-entry-view/blog-entry-view.component.html
@@ -3,8 +3,8 @@
 
     @if (!entry) {
       <div class="not-found">
-        <p>Entry not found.</p>
-        <button class="back-link" (click)="navigateToBlog()">← Back to Blog</button>
+        <p>{{ 'blog.notFound' | transloco }}</p>
+        <button class="back-link" (click)="navigateToBlog()">← {{ 'blog.backToBlog' | transloco }}</button>
       </div>
     }
 
@@ -13,7 +13,7 @@
       <!-- ── Breadcrumb + actions ──────────────────────────────────── -->
       <div class="view-topbar">
         <div class="breadcrumb">
-          <button class="bc-item bc-link" (click)="navigateToBlog()">Blog</button>
+          <button class="bc-item bc-link" (click)="navigateToBlog()">{{ 'blog.title' | transloco }}</button>
           <span class="bc-sep">/</span>
           <button class="bc-item bc-link" (click)="navigateToBlog()">{{ categoryLabel }}</button>
           <span class="bc-sep">/</span>
@@ -24,12 +24,12 @@
       <div class="view-actions-row">
         <button class="back-btn" (click)="goBack()">
           <ion-icon name="arrow-back-outline"></ion-icon>
-          Back
+          {{ 'common.back' | transloco }}
         </button>
         <div class="action-btns">
           <button class="action-btn action-btn--primary" (click)="editEntry()">
             <ion-icon name="create-outline"></ion-icon>
-            Edit
+            {{ 'common.edit' | transloco }}
           </button>
           <div class="more-wrap">
             <button class="action-btn" (click)="toggleMoreMenu($event)">
@@ -39,15 +39,15 @@
               <div class="more-menu" (click)="$event.stopPropagation()">
                 <button class="more-menu-item" (click)="closeMoreMenu()">
                   <ion-icon name="pin-outline"></ion-icon>
-                  {{ entry.is_pinned ? 'Unpin' : 'Pin' }}
+                  {{ (entry.is_pinned ? 'blog.entry.unpin' : 'blog.entry.pin') | transloco }}
                 </button>
                 <button class="more-menu-item" (click)="closeMoreMenu()">
                   <ion-icon name="share-outline"></ion-icon>
-                  Share
+                  {{ 'common.share' | transloco }}
                 </button>
                 <button class="more-menu-item danger" (click)="navigateToBlog()">
                   <ion-icon name="trash-outline"></ion-icon>
-                  Delete
+                  {{ 'common.delete' | transloco }}
                 </button>
               </div>
             }
@@ -70,7 +70,7 @@
             <span class="entry-car">· {{ entry.car_name }}</span>
           }
           <span class="entry-status" [class.published]="entry.status === 'PUBLISHED'">
-            {{ entry.status === 'PUBLISHED' ? 'Published' : 'Draft' }}
+            {{ (entry.status === 'PUBLISHED' ? 'blog.status.published' : 'blog.status.draft') | transloco }}
           </span>
         </div>
 
@@ -80,7 +80,7 @@
           <div class="vehicle-info-row">
             <span class="vehicle-cat-badge">
               <ion-icon [name]="vehicleCategoryIcon(entry.vehicle_category)"></ion-icon>
-              {{ VEHICLE_ENTRY_CATEGORY_LABELS[entry.vehicle_category] }}
+              {{ VEHICLE_ENTRY_CATEGORY_LABELS[entry.vehicle_category] | transloco }}
             </span>
             @if (entry.km) {
               <span class="vehicle-stat">{{ entry.km | number }} km</span>

--- a/src/app/features/blog/blog-entry-view/blog-entry-view.component.ts
+++ b/src/app/features/blog/blog-entry-view/blog-entry-view.component.ts
@@ -17,12 +17,13 @@ import { BlogFacade } from '@hau/features/blog/state/blog.facade';
 import {
   VehicleEntryCategory, VEHICLE_ENTRY_CATEGORY_LABELS,
 } from '@hau/features/blog/models/blog.model';
+import { TranslocoPipe, TranslocoService } from '@ngneat/transloco';
 
 @Component({
   selector: 'app-blog-entry-view',
   templateUrl: 'blog-entry-view.component.html',
   styleUrls: ['./blog-entry-view.component.scss'],
-  imports: [IonContent, IonIcon, DatePipe, DecimalPipe],
+  imports: [IonContent, IonIcon, DatePipe, DecimalPipe, TranslocoPipe],
 })
 export class BlogEntryViewComponent implements OnInit {
   readonly VEHICLE_ENTRY_CATEGORY_LABELS = VEHICLE_ENTRY_CATEGORY_LABELS;
@@ -32,7 +33,7 @@ export class BlogEntryViewComponent implements OnInit {
   renderedHtml = '';
 
   get categoryLabel(): string {
-    return this.entry?.category === 'VEHICLE' ? 'Vehicle Journal' : 'Personal';
+    return this._transloco.translate(this.entry?.category === 'VEHICLE' ? 'blog.tabs.vehicle' : 'blog.tabs.personal');
   }
 
   get contentParagraphs(): string[] {
@@ -66,6 +67,7 @@ export class BlogEntryViewComponent implements OnInit {
     private route: ActivatedRoute,
     private navCtrl: NavController,
     private blogFacade: BlogFacade,
+    private readonly _transloco: TranslocoService,
   ) {
     addIcons({
       arrowBackOutline, createOutline, ellipsisHorizontalOutline,

--- a/src/app/features/blog/blog-entry-write/blog-entry-write.component.html
+++ b/src/app/features/blog/blog-entry-write/blog-entry-write.component.html
@@ -7,10 +7,10 @@
     <div class="write-header">
       <button class="cancel-btn" type="button" (click)="cancel()">
         <ion-icon name="close-outline"></ion-icon>
-        Cancel
+        {{ 'common.cancel' | transloco }}
       </button>
       <h1 class="write-heading">
-        {{ form.controls.title.value || (isEditMode ? 'Edit Entry' : 'New Entry') }}
+        {{ headingLabel }}
       </h1>
     </div>
 
@@ -21,14 +21,14 @@
         class="cat-btn"
         [class.active]="activeCategory === 'PERSONAL'"
         (click)="setCategory('PERSONAL')">
-        Personal
+        {{ 'blog.tabs.personal' | transloco }}
       </button>
       <button
         type="button"
         class="cat-btn"
         [class.active]="activeCategory === 'VEHICLE'"
         (click)="setCategory('VEHICLE')">
-        Vehicle Journal
+        {{ 'blog.tabs.vehicle' | transloco }}
       </button>
     </div>
 
@@ -39,30 +39,30 @@
       <form class="write-form" [formGroup]="form" (ngSubmit)="publish()">
 
         <div class="step-group">
-          <label class="form-label" for="p-date">Date <span class="req">*</span></label>
+          <label class="form-label" for="p-date">{{ 'blog.form.date' | transloco }} <span class="req">*</span></label>
           <input id="p-date" type="date" class="form-input" [formControl]="form.controls.date" />
         </div>
 
         <div class="step-group">
-          <label class="form-label" for="p-title">Title <span class="req">*</span></label>
+          <label class="form-label" for="p-title">{{ 'blog.form.title' | transloco }} <span class="req">*</span></label>
           <input
             id="p-title"
             type="text"
             class="form-input"
-            placeholder="Give your entry a title"
+            [placeholder]="'blog.form.titlePlaceholder' | transloco"
             [formControl]="form.controls.title"
             [class.invalid]="isInvalid(form.controls.title)" />
           @if (isInvalid(form.controls.title)) {
-            <span class="field-error">Title is required</span>
+            <span class="field-error">{{ 'blog.form.titleRequired' | transloco }}</span>
           }
         </div>
 
         <!-- Cover image -->
         <div class="step-group">
-          <label class="form-label">Cover image <span class="opt">(optional)</span></label>
+          <label class="form-label">{{ 'blog.form.coverImage' | transloco }} <span class="opt">({{ 'blog.form.coverImageOptional' | transloco }})</span></label>
           @if (coverImageUrl) {
             <div class="cover-preview">
-              <img [src]="coverImageUrl" alt="Cover" class="cover-preview-img" />
+              <img [src]="coverImageUrl" [alt]="'blog.form.coverAlt' | transloco" class="cover-preview-img" />
               <button type="button" class="cover-remove-btn" (click)="removeCover()">
                 <ion-icon name="close-outline"></ion-icon>
               </button>
@@ -70,21 +70,21 @@
           } @else {
             <button type="button" class="cover-upload-btn" (click)="triggerCoverInput()">
               <ion-icon name="cloud-upload-outline"></ion-icon>
-              Upload cover image
+              {{ 'blog.form.coverImageUpload' | transloco }}
             </button>
           }
         </div>
 
         <div class="step-group">
-          <label class="form-label">Content</label>
+          <label class="form-label">{{ 'blog.form.content' | transloco }}</label>
           <app-tiptap-editor
             [formControl]="form.controls.contentJson"
-            placeholder="Write your story here…">
+            [placeholder]="'blog.form.contentPlaceholder' | transloco">
           </app-tiptap-editor>
         </div>
 
         <div class="step-group">
-          <label class="form-label">Tags</label>
+          <label class="form-label">{{ 'blog.form.tags' | transloco }}</label>
           <div class="tags-field">
             @for (tag of tags; track tag.label) {
               <span class="tag-chip tag--{{ tag.color }}">
@@ -97,7 +97,7 @@
             <input
               type="text"
               class="tag-input"
-              placeholder="Add tag"
+              [placeholder]="'blog.form.addTag' | transloco"
               [value]="tagInput"
               (input)="onTagInputChange($event)"
               (keydown)="onTagInputKeydown($event)" />
@@ -105,21 +105,21 @@
               <ion-icon name="add-outline"></ion-icon>
             </button>
           </div>
-          <span class="field-hint">Press Enter or comma to add</span>
+          <span class="field-hint">{{ 'blog.form.tagsHint' | transloco }}</span>
         </div>
 
         <div class="write-footer">
           <div class="draft-status">
             @if (draftSaved) {
               <ion-icon name="checkmark-circle-outline" class="draft-icon"></ion-icon>
-              <span class="draft-text">Draft saved</span>
+              <span class="draft-text">{{ 'blog.entry.draftSaved' | transloco }}</span>
             }
           </div>
           <div class="footer-btns">
-            <button type="button" class="btn-draft" (click)="saveDraft()" [disabled]="isSaving">Save draft</button>
+            <button type="button" class="btn-draft" (click)="saveDraft()" [disabled]="isSaving">{{ 'blog.form.saveDraft' | transloco }}</button>
             <button type="submit" class="btn-publish" [disabled]="isSaving">
               @if (isSaving) { <ion-spinner name="crescent" class="btn-spinner"></ion-spinner> }
-              Publish
+              {{ 'blog.form.publish' | transloco }}
             </button>
           </div>
         </div>
@@ -151,7 +151,7 @@
         <div class="step2-topbar">
           <button type="button" class="step2-back-btn" (click)="prevMobileStep()">
             <ion-icon name="arrow-back-outline"></ion-icon>
-            Details
+            {{ 'blog.form.details' | transloco }}
           </button>
           @if (form.controls.title.value) {
             <span class="step2-title">{{ form.controls.title.value }}</span>
@@ -160,7 +160,7 @@
 
         <!-- ── 1. Vehicle selector ───────────────────────────────────── -->
         <div class="vj-vehicle">
-          <label class="form-label">Select vehicle</label>
+          <label class="form-label">{{ 'blog.form.selectVehicle' | transloco }}</label>
           <div class="car-picker-grid">
             @for (car of cars; track car.id) {
               <button
@@ -196,25 +196,25 @@
           <!-- Title + Category — side by side row -->
           <div class="title-cat-row">
             <div class="step-group title-group">
-              <label class="form-label" for="vj-title">Title <span class="req">*</span></label>
+              <label class="form-label" for="vj-title">{{ 'blog.form.title' | transloco }} <span class="req">*</span></label>
               <input
                 id="vj-title"
                 type="text"
                 class="form-input"
-                placeholder="Brief description of the event"
+                [placeholder]="'blog.form.vjTitlePlaceholder' | transloco"
                 [formControl]="form.controls.title"
                 [class.invalid]="isInvalid(form.controls.title)" />
               @if (isInvalid(form.controls.title)) {
-                <span class="field-error">Title is required</span>
+                <span class="field-error">{{ 'blog.form.titleRequired' | transloco }}</span>
               }
             </div>
             <div class="step-group cat-group">
-              <label class="form-label" for="vj-cat">Category</label>
+              <label class="form-label" for="vj-cat">{{ 'blog.form.category' | transloco }}</label>
               <div class="select-wrap">
                 <select id="vj-cat" class="form-select" [formControl]="form.controls.vehicleCategory">
-                  <option [value]="null">Select category</option>
+                  <option [value]="null">{{ 'blog.form.selectCategory' | transloco }}</option>
                   @for (cat of VEHICLE_ENTRY_CATEGORIES; track cat.value) {
-                    <option [value]="cat.value">{{ cat.label }}</option>
+                    <option [value]="cat.value">{{ cat.label | transloco }}</option>
                   }
                 </select>
                 <ion-icon name="chevron-down-outline" class="select-chevron"></ion-icon>
@@ -224,10 +224,10 @@
 
           <!-- Cover image -->
           <div class="step-group">
-            <label class="form-label">Cover image <span class="opt">(optional)</span></label>
+            <label class="form-label">{{ 'blog.form.coverImage' | transloco }} <span class="opt">({{ 'blog.form.coverImageOptional' | transloco }})</span></label>
             @if (coverImageUrl) {
               <div class="cover-preview">
-                <img [src]="coverImageUrl" alt="Cover" class="cover-preview-img" />
+                <img [src]="coverImageUrl" [alt]="'blog.form.coverAlt' | transloco" class="cover-preview-img" />
                 <button type="button" class="cover-remove-btn" (click)="removeCover()">
                   <ion-icon name="close-outline"></ion-icon>
                 </button>
@@ -235,23 +235,23 @@
             } @else {
               <button type="button" class="cover-upload-btn" (click)="triggerCoverInput()">
                 <ion-icon name="cloud-upload-outline"></ion-icon>
-                Upload cover image
+                {{ 'blog.form.coverImageUpload' | transloco }}
               </button>
             }
           </div>
 
           <!-- Content / Body -->
           <div class="step-group content-group">
-            <label class="form-label">Notes / Story</label>
+            <label class="form-label">{{ 'blog.form.notesStory' | transloco }}</label>
             <app-tiptap-editor
               [formControl]="form.controls.contentJson"
-              placeholder="Describe what happened, what you noticed, what was replaced…">
+              [placeholder]="'blog.form.vjContentPlaceholder' | transloco">
             </app-tiptap-editor>
           </div>
 
           <!-- Photos — right below content -->
           <div class="step-group">
-            <label class="form-label">Photos <span class="opt">(optional)</span></label>
+            <label class="form-label">{{ 'blog.form.photos' | transloco }} <span class="opt">({{ 'blog.form.coverImageOptional' | transloco }})</span></label>
 
             <input
               #photoInput
@@ -269,8 +269,8 @@
               (dragleave)="onDragLeave()"
               (drop)="onDrop($event)">
               <ion-icon name="images-outline" class="upload-icon"></ion-icon>
-              <span class="upload-label">Upload photos</span>
-              <span class="upload-hint">PNG, JPG up to 10 MB</span>
+              <span class="upload-label">{{ 'blog.form.uploadPhotos' | transloco }}</span>
+              <span class="upload-hint">{{ 'blog.form.photoHint' | transloco }}</span>
             </div>
 
             @if (photos.length > 0) {
@@ -292,9 +292,9 @@
 
           <!-- Mobile step-1: Cancel + Next -->
           <div class="step1-nav">
-            <button type="button" class="btn-cancel step1-cancel" (click)="cancel()">Cancel</button>
+            <button type="button" class="btn-cancel step1-cancel" (click)="cancel()">{{ 'common.cancel' | transloco }}</button>
             <button type="button" class="btn-next" (click)="nextMobileStep()">
-              Next
+              {{ 'blog.form.next' | transloco }}
               <ion-icon name="arrow-forward-outline"></ion-icon>
             </button>
           </div>
@@ -307,27 +307,27 @@
 
             <!-- Date + Mileage + Price -->
             <div class="meta-col step-group">
-              <label class="form-label">Date <span class="req">*</span></label>
+              <label class="form-label">{{ 'blog.form.date' | transloco }} <span class="req">*</span></label>
               <input type="date" class="form-input" [formControl]="form.controls.date" />
 
-              <label class="form-label top-gap">Mileage (km)</label>
+              <label class="form-label top-gap">{{ 'blog.form.mileage' | transloco }}</label>
               <input
                 type="number"
                 class="form-input"
-                placeholder="e.g. 184 200"
+                [placeholder]="'blog.form.mileagePlaceholder' | transloco"
                 [formControl]="form.controls.km" />
 
-              <label class="form-label top-gap">Price / Cost (RON)</label>
+              <label class="form-label top-gap">{{ 'blog.form.cost' | transloco }}</label>
               <input
                 type="number"
                 class="form-input"
-                placeholder="Optional"
+                [placeholder]="'blog.form.optionalPlaceholder' | transloco"
                 [formControl]="form.controls.price" />
             </div>
 
             <!-- Tags -->
             <div class="meta-col step-group">
-              <label class="form-label">Tags</label>
+              <label class="form-label">{{ 'blog.form.tags' | transloco }}</label>
               <div class="tags-field">
                 @for (tag of tags; track tag.label) {
                   <span class="tag-chip tag--{{ tag.color }}">
@@ -340,7 +340,7 @@
                 <input
                   type="text"
                   class="tag-input"
-                  placeholder="Add tag"
+                  [placeholder]="'blog.form.addTag' | transloco"
                   [value]="tagInput"
                   (input)="onTagInputChange($event)"
                   (keydown)="onTagInputKeydown($event)" />
@@ -348,7 +348,7 @@
                   <ion-icon name="add-outline"></ion-icon>
                 </button>
               </div>
-              <span class="field-hint">Press Enter or comma to add</span>
+              <span class="field-hint">{{ 'blog.form.tagsHint' | transloco }}</span>
             </div>
 
           </div>
@@ -359,15 +359,15 @@
           <div class="draft-status">
             @if (draftSaved) {
               <ion-icon name="checkmark-circle-outline" class="draft-icon"></ion-icon>
-              <span class="draft-text">Saved</span>
+              <span class="draft-text">{{ 'blog.form.saved' | transloco }}</span>
             }
           </div>
           <div class="footer-btns">
-            <button type="button" class="btn-cancel" (click)="cancel()" [disabled]="isSaving">Cancel</button>
-            <button type="button" class="btn-draft" (click)="saveDraft()" [disabled]="isSaving">Save draft</button>
+            <button type="button" class="btn-cancel" (click)="cancel()" [disabled]="isSaving">{{ 'common.cancel' | transloco }}</button>
+            <button type="button" class="btn-draft" (click)="saveDraft()" [disabled]="isSaving">{{ 'blog.form.saveDraft' | transloco }}</button>
             <button type="submit" class="btn-publish" [disabled]="isSaving">
               @if (isSaving) { <ion-spinner name="crescent" class="btn-spinner"></ion-spinner> }
-              Publish
+              {{ 'blog.form.publish' | transloco }}
             </button>
           </div>
         </div>
@@ -392,18 +392,18 @@
         <button type="button" class="confirm-close" (click)="showCancelConfirm = false">
           <ion-icon name="close-outline"></ion-icon>
         </button>
-        <h2 class="confirm-title">Unsaved changes</h2>
-        <p class="confirm-body">You have unsaved changes. Would you like to save before leaving?</p>
+        <h2 class="confirm-title">{{ 'blog.confirmCancel.title' | transloco }}</h2>
+        <p class="confirm-body">{{ 'blog.confirmCancel.body' | transloco }}</p>
         <div class="confirm-actions">
           <button type="button" class="confirm-btn confirm-draft" (click)="confirmSaveDraft()">
-            Save draft
+            {{ 'blog.form.saveDraft' | transloco }}
           </button>
           <button type="button" class="confirm-btn confirm-discard" (click)="confirmDiscard()">
-            Discard &amp; leave
+            {{ 'blog.confirmCancel.discard' | transloco }}
           </button>
         </div>
         <button type="button" class="confirm-keep" (click)="showCancelConfirm = false">
-          Keep editing
+          {{ 'blog.confirmCancel.keepEditing' | transloco }}
         </button>
       </div>
     </div>

--- a/src/app/features/blog/blog-entry-write/blog-entry-write.component.ts
+++ b/src/app/features/blog/blog-entry-write/blog-entry-write.component.ts
@@ -19,6 +19,7 @@ import {
   VEHICLE_ENTRY_CATEGORIES, assignTagColor, carGradient,
 } from '@hau/features/blog/models/blog.model';
 import { TiptapEditorComponent } from '@hau/features/blog/components/tiptap-editor/tiptap-editor.component';
+import { TranslocoPipe, TranslocoService } from '@ngneat/transloco';
 import { environment } from '../../../../environments/environment';
 
 interface PhotoEntry {
@@ -40,7 +41,7 @@ interface WriteForm {
   selector: 'app-blog-entry-write',
   templateUrl: 'blog-entry-write.component.html',
   styleUrls: ['./blog-entry-write.component.scss'],
-  imports: [IonContent, IonIcon, IonSpinner, ReactiveFormsModule, DecimalPipe, TiptapEditorComponent],
+  imports: [IonContent, IonIcon, IonSpinner, ReactiveFormsModule, DecimalPipe, TiptapEditorComponent, TranslocoPipe],
 })
 export class BlogEntryWriteComponent implements OnInit {
   readonly VEHICLE_ENTRY_CATEGORIES = VEHICLE_ENTRY_CATEGORIES;
@@ -89,6 +90,11 @@ export class BlogEntryWriteComponent implements OnInit {
 
   get isVehicle(): boolean { return this.activeCategory === 'VEHICLE'; }
 
+  get headingLabel(): string {
+    return this.form.controls.title.value
+      || this._transloco.translate(this.isEditMode ? 'blog.writeHeading.edit' : 'blog.writeHeading.new');
+  }
+
   carGradient = carGradient;
 
   constructor(
@@ -97,6 +103,7 @@ export class BlogEntryWriteComponent implements OnInit {
     private blogFacade: BlogFacade,
     private carService: CarService,
     private blogService: BlogService,
+    private readonly _transloco: TranslocoService,
   ) {
     addIcons({
       arrowBackOutline, arrowForwardOutline, closeOutline, checkmarkCircleOutline, addOutline,

--- a/src/app/features/blog/blog-list/blog-list.component.html
+++ b/src/app/features/blog/blog-list/blog-list.component.html
@@ -10,7 +10,7 @@
           <input
             class="search-input"
             type="text"
-            placeholder="Search entries"
+            [placeholder]="'blog.filters.search' | transloco"
             [value]="searchQuery"
             (input)="onSearchInput($event)"
             (click)="$event.stopPropagation()" />
@@ -21,7 +21,7 @@
           <div class="new-entry-wrap" (click)="$event.stopPropagation()">
             <button class="new-entry-main" (click)="navigateToNewEntry('PERSONAL')">
               <ion-icon name="add-outline"></ion-icon>
-              New entry
+              {{ 'blog.newEntry' | transloco }}
             </button>
             <button class="new-entry-arrow" [class.open]="showNewEntryMenu" (click)="toggleNewEntryMenu($event)">
               <ion-icon name="chevron-down-outline"></ion-icon>
@@ -30,11 +30,11 @@
               <div class="new-entry-dropdown" (click)="$event.stopPropagation()">
                 <button class="dropdown-item" (click)="navigateToNewEntry('PERSONAL')">
                   <ion-icon name="create-outline"></ion-icon>
-                  Personal entry
+                  {{ 'blog.newEntryOptions.personal' | transloco }}
                 </button>
                 <button class="dropdown-item" (click)="navigateToNewEntry('VEHICLE')">
                   <ion-icon name="car-outline"></ion-icon>
-                  Vehicle Journal
+                  {{ 'blog.newEntryOptions.vehicle' | transloco }}
                 </button>
               </div>
             }
@@ -42,7 +42,7 @@
         } @else {
           <button class="new-entry-solo" (click)="newEntryFromCarTab()">
             <ion-icon name="add-outline"></ion-icon>
-            New entry
+            {{ 'blog.newEntry' | transloco }}
           </button>
         }
       </div>
@@ -70,26 +70,26 @@
             class="cat-chip"
             [class.active]="selectedVehicleCat === 'all'"
             (click)="setVehicleCat('all')">
-            All
+            {{ 'blog.filters.all' | transloco }}
           </button>
           @for (cat of VEHICLE_CATEGORY_CHIPS_PRIMARY; track cat) {
             <button
               class="cat-chip"
               [class.active]="selectedVehicleCat === cat"
               (click)="setVehicleCat(cat)">
-              {{ VEHICLE_ENTRY_CATEGORY_LABELS[cat] }}
+              {{ VEHICLE_ENTRY_CATEGORY_LABELS[cat] | transloco }}
             </button>
           }
           @if (extraVehicleCats.length > 0) {
             <div class="more-cats-wrap">
               <button class="cat-chip cat-chip--more" (click)="toggleMoreCats($event)">
-                More <ion-icon name="chevron-down-outline"></ion-icon>
+                {{ 'blog.filters.more' | transloco }} <ion-icon name="chevron-down-outline"></ion-icon>
               </button>
               @if (showMoreCats) {
                 <div class="more-cats-dropdown">
                   @for (cat of extraVehicleCats; track cat.value) {
                     <button class="more-cat-item" (click)="setVehicleCat(cat.value); showMoreCats = false">
-                      {{ cat.label }}
+                      {{ cat.label | transloco }}
                     </button>
                   }
                 </div>
@@ -105,7 +105,7 @@
       <div class="personal-filters" (click)="$event.stopPropagation()">
         <div class="filter-select-wrap">
           <select class="filter-select" [value]="selectedTag" (change)="onTagChange($event)">
-            <option value="">All tags</option>
+            <option value="">{{ 'blog.filters.allTags' | transloco }}</option>
             @for (tag of availableTags; track tag.label) {
               <option [value]="tag.label">{{ tag.label }}</option>
             }
@@ -114,8 +114,8 @@
         </div>
         <div class="filter-select-wrap">
           <select class="filter-select" [value]="sortOrder" (change)="onSortChange($event)">
-            <option value="newest">Newest first</option>
-            <option value="oldest">Oldest first</option>
+            <option value="newest">{{ 'blog.filters.newestFirst' | transloco }}</option>
+            <option value="oldest">{{ 'blog.filters.oldestFirst' | transloco }}</option>
           </select>
           <ion-icon name="chevron-down-outline" class="select-chevron"></ion-icon>
         </div>
@@ -125,7 +125,7 @@
           <input
             class="search-input"
             type="text"
-            placeholder="Search entries"
+            [placeholder]="'blog.filters.search' | transloco"
             [value]="searchQuery"
             (input)="onSearchInput($event)" />
         </div>
@@ -145,7 +145,7 @@
         <section class="blog-section">
           <h2 class="section-label">
             <ion-icon name="pin-outline"></ion-icon>
-            Pinned
+            {{ 'blog.sections.pinned' | transloco }}
           </h2>
           <div class="pinned-grid">
             @for (entry of pinnedEntries; track entry.id) {
@@ -166,14 +166,14 @@
                 @if (openEntryMenuId === entry.id) {
                   <div class="entry-menu" (click)="$event.stopPropagation()">
                     <button class="entry-menu-item" (click)="editEntry($event, entry)">
-                      <ion-icon name="create-outline"></ion-icon> Edit
+                      <ion-icon name="create-outline"></ion-icon> {{ 'common.edit' | transloco }}
                     </button>
                     <button class="entry-menu-item" (click)="togglePin($event, entry)">
                       <ion-icon name="bookmark-outline"></ion-icon>
-                      {{ entry.is_pinned ? 'Unpin' : 'Pin' }}
+                      {{ (entry.is_pinned ? 'blog.entry.unpin' : 'blog.entry.pin') | transloco }}
                     </button>
                     <button class="entry-menu-item danger" (click)="deleteEntry($event, entry)">
-                      <ion-icon name="trash-outline"></ion-icon> Delete
+                      <ion-icon name="trash-outline"></ion-icon> {{ 'common.delete' | transloco }}
                     </button>
                   </div>
                 }
@@ -185,13 +185,13 @@
 
       <!-- All personal entries list -->
       <section class="blog-section">
-        <h2 class="section-title">All entries</h2>
+        <h2 class="section-title">{{ 'blog.sections.allEntries' | transloco }}</h2>
         @if (filteredEntries.length === 0) {
           <div class="empty-state">
             <ion-icon name="create-outline" class="empty-icon"></ion-icon>
-            <p class="empty-text">No entries yet. Start writing!</p>
+            <p class="empty-text">{{ 'blog.empty.personal' | transloco }}</p>
             <button class="empty-cta" (click)="navigateToNewEntry('PERSONAL')">
-              <ion-icon name="add-outline"></ion-icon> New entry
+              <ion-icon name="add-outline"></ion-icon> {{ 'blog.newEntry' | transloco }}
             </button>
           </div>
         }
@@ -215,14 +215,14 @@
                 @if (openEntryMenuId === entry.id) {
                   <div class="entry-menu entry-menu--right" (click)="$event.stopPropagation()">
                     <button class="entry-menu-item" (click)="editEntry($event, entry)">
-                      <ion-icon name="create-outline"></ion-icon> Edit
+                      <ion-icon name="create-outline"></ion-icon> {{ 'common.edit' | transloco }}
                     </button>
                     <button class="entry-menu-item" (click)="togglePin($event, entry)">
                       <ion-icon name="bookmark-outline"></ion-icon>
-                      {{ entry.is_pinned ? 'Unpin' : 'Pin' }}
+                      {{ (entry.is_pinned ? 'blog.entry.unpin' : 'blog.entry.pin') | transloco }}
                     </button>
                     <button class="entry-menu-item danger" (click)="deleteEntry($event, entry)">
-                      <ion-icon name="trash-outline"></ion-icon> Delete
+                      <ion-icon name="trash-outline"></ion-icon> {{ 'common.delete' | transloco }}
                     </button>
                   </div>
                 }
@@ -242,9 +242,9 @@
       @if (filteredEntries.length === 0) {
         <div class="empty-state">
           <ion-icon name="car-outline" class="empty-icon"></ion-icon>
-          <p class="empty-text">No entries for this vehicle yet.</p>
+          <p class="empty-text">{{ 'blog.empty.vehicle' | transloco }}</p>
           <button class="empty-cta" (click)="newEntryFromCarTab()">
-            <ion-icon name="add-outline"></ion-icon> New entry
+            <ion-icon name="add-outline"></ion-icon> {{ 'blog.newEntry' | transloco }}
           </button>
         </div>
       }
@@ -268,7 +268,7 @@
               <div class="vehicle-row-chips">
                 @if (entry.vehicle_category) {
                   <span class="vcat-chip vcat-chip--{{ entry.vehicle_category.toLowerCase() }}">
-                    {{ VEHICLE_ENTRY_CATEGORY_LABELS[entry.vehicle_category] }}
+                    {{ VEHICLE_ENTRY_CATEGORY_LABELS[entry.vehicle_category] | transloco }}
                   </span>
                 }
                 @for (tag of entry.tags; track tag.label) {
@@ -296,10 +296,10 @@
               @if (openEntryMenuId === entry.id) {
                 <div class="entry-menu entry-menu--right" (click)="$event.stopPropagation()">
                   <button class="entry-menu-item" (click)="editEntry($event, entry)">
-                    <ion-icon name="create-outline"></ion-icon> Edit
+                    <ion-icon name="create-outline"></ion-icon> {{ 'common.edit' | transloco }}
                   </button>
                   <button class="entry-menu-item danger" (click)="deleteEntry($event, entry)">
-                    <ion-icon name="trash-outline"></ion-icon> Delete
+                    <ion-icon name="trash-outline"></ion-icon> {{ 'common.delete' | transloco }}
                   </button>
                 </div>
               }
@@ -309,14 +309,14 @@
         }
 
         @if (filteredEntries.length > 0) {
-          <div class="list-end-note">No more entries</div>
+          <div class="list-end-note">{{ 'blog.noMoreEntries' | transloco }}</div>
         }
       </div>
 
       <!-- Mobile floating new entry button -->
       <div class="fab-new-entry" (click)="newEntryFromCarTab()">
         <ion-icon name="add-outline"></ion-icon>
-        New entry
+        {{ 'blog.newEntry' | transloco }}
       </div>
 
     }

--- a/src/app/features/blog/blog-list/blog-list.component.ts
+++ b/src/app/features/blog/blog-list/blog-list.component.ts
@@ -19,6 +19,7 @@ import {
   VEHICLE_ENTRY_CATEGORIES, VEHICLE_CATEGORY_CHIPS_PRIMARY,
   carGradient,
 } from '@hau/features/blog/models/blog.model';
+import { TranslocoPipe, TranslocoService } from '@ngneat/transloco';
 
 type SortOrder = 'newest' | 'oldest';
 
@@ -32,7 +33,7 @@ export interface CarTab {
   selector: 'app-blog-list',
   templateUrl: 'blog-list.component.html',
   styleUrls: ['./blog-list.component.scss'],
-  imports: [IonContent, IonIcon, DatePipe, DecimalPipe, NgStyle],
+  imports: [IonContent, IonIcon, DatePipe, DecimalPipe, NgStyle, TranslocoPipe],
 })
 export class BlogListComponent implements OnInit {
   readonly VEHICLE_ENTRY_CATEGORY_LABELS = VEHICLE_ENTRY_CATEGORY_LABELS;
@@ -75,6 +76,7 @@ export class BlogListComponent implements OnInit {
     private readonly navCtrl: NavController,
     private readonly blogFacade: BlogFacade,
     private readonly carService: CarService,
+    private readonly _transloco: TranslocoService,
   ) {
     addIcons({
       addOutline, chevronDownOutline, pinOutline, searchOutline,
@@ -90,7 +92,7 @@ export class BlogListComponent implements OnInit {
     this.carService.carControllerGetAllCars().subscribe(cars => {
       this.cars = cars;
       this.tabs = [
-        { key: 'personal', label: 'Personal', carId: null },
+        { key: 'personal', label: this._transloco.translate('blog.tabs.personal'), carId: null },
         ...cars.map(c => ({ key: `car-${c.id}`, label: `${c.make} ${c.model}`, carId: c.id })),
       ];
     });

--- a/src/app/features/blog/components/tiptap-editor/tiptap-editor.component.html
+++ b/src/app/features/blog/components/tiptap-editor/tiptap-editor.component.html
@@ -1,43 +1,43 @@
 <div class="tiptap-editor-wrap">
 
   <!-- ── Toolbar ──────────────────────────────────────────────────── -->
-  <div class="tiptap-toolbar" role="toolbar" aria-label="Editor toolbar">
+  <div class="tiptap-toolbar" role="toolbar" [attr.aria-label]="'blog.editor.toolbarLabel' | transloco">
 
-    <button type="button" class="tb-btn" [class.active]="isActive('bold')" (click)="toggleBold()" title="Bold">
+    <button type="button" class="tb-btn" [class.active]="isActive('bold')" (click)="toggleBold()" [attr.title]="'blog.editor.bold' | transloco">
       <strong>B</strong>
     </button>
-    <button type="button" class="tb-btn tb-italic" [class.active]="isActive('italic')" (click)="toggleItalic()" title="Italic">
+    <button type="button" class="tb-btn tb-italic" [class.active]="isActive('italic')" (click)="toggleItalic()" [attr.title]="'blog.editor.italic' | transloco">
       <em>I</em>
     </button>
 
     <span class="tb-sep"></span>
 
-    <button type="button" class="tb-btn" [class.active]="isActive('heading', {level: 2})" (click)="setHeading(2)" title="Heading 2">
+    <button type="button" class="tb-btn" [class.active]="isActive('heading', {level: 2})" (click)="setHeading(2)" [attr.title]="'blog.editor.heading2' | transloco">
       H2
     </button>
-    <button type="button" class="tb-btn" [class.active]="isActive('heading', {level: 3})" (click)="setHeading(3)" title="Heading 3">
+    <button type="button" class="tb-btn" [class.active]="isActive('heading', {level: 3})" (click)="setHeading(3)" [attr.title]="'blog.editor.heading3' | transloco">
       H3
     </button>
 
     <span class="tb-sep"></span>
 
-    <button type="button" class="tb-btn" [class.active]="isActive('bulletList')" (click)="toggleBulletList()" title="Bullet list">
+    <button type="button" class="tb-btn" [class.active]="isActive('bulletList')" (click)="toggleBulletList()" [attr.title]="'blog.editor.bulletList' | transloco">
       <ion-icon name="list-outline"></ion-icon>
     </button>
-    <button type="button" class="tb-btn" [class.active]="isActive('orderedList')" (click)="toggleOrderedList()" title="Ordered list">
+    <button type="button" class="tb-btn" [class.active]="isActive('orderedList')" (click)="toggleOrderedList()" [attr.title]="'blog.editor.orderedList' | transloco">
       <ion-icon name="list-circle-outline"></ion-icon>
     </button>
-    <button type="button" class="tb-btn" [class.active]="isActive('blockquote')" (click)="toggleBlockquote()" title="Blockquote">
+    <button type="button" class="tb-btn" [class.active]="isActive('blockquote')" (click)="toggleBlockquote()" [attr.title]="'blog.editor.blockquote' | transloco">
       "
     </button>
 
     <span class="tb-sep"></span>
 
-    <button type="button" class="tb-btn" [class.active]="isActive('link')" (click)="setLink()" title="Link">
+    <button type="button" class="tb-btn" [class.active]="isActive('link')" (click)="setLink()" [attr.title]="'blog.editor.link' | transloco">
       <ion-icon name="link-outline"></ion-icon>
     </button>
 
-    <button type="button" class="tb-btn tb-img-btn" (click)="triggerImageUpload()" title="Insert image" [disabled]="isUploadingImage">
+    <button type="button" class="tb-btn tb-img-btn" (click)="triggerImageUpload()" [attr.title]="'blog.editor.image' | transloco" [disabled]="isUploadingImage">
       @if (isUploadingImage) {
         <ion-spinner name="crescent" class="tb-spinner"></ion-spinner>
       } @else {

--- a/src/app/features/blog/components/tiptap-editor/tiptap-editor.component.ts
+++ b/src/app/features/blog/components/tiptap-editor/tiptap-editor.component.ts
@@ -12,6 +12,7 @@ import Image from '@tiptap/extension-image';
 import Link from '@tiptap/extension-link';
 import Placeholder from '@tiptap/extension-placeholder';
 import { BlogService } from '@hau/autogenapi/services';
+import { TranslocoPipe, TranslocoService } from '@ngneat/transloco';
 import { environment } from '../../../../../environments/environment';
 
 @Component({
@@ -19,7 +20,7 @@ import { environment } from '../../../../../environments/environment';
   templateUrl: './tiptap-editor.component.html',
   styleUrls: ['./tiptap-editor.component.scss'],
   encapsulation: ViewEncapsulation.None,
-  imports: [IonIcon, IonSpinner],
+  imports: [IonIcon, IonSpinner, TranslocoPipe],
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
@@ -46,6 +47,7 @@ export class TiptapEditorComponent implements AfterViewInit, OnDestroy, ControlV
   constructor(
     private blogService: BlogService,
     private zone: NgZone,
+    private readonly _transloco: TranslocoService,
   ) {
     addIcons({ listOutline, listCircleOutline, linkOutline, imageOutline });
   }
@@ -112,7 +114,7 @@ export class TiptapEditorComponent implements AfterViewInit, OnDestroy, ControlV
 
   setLink(): void {
     const prev = this.editor?.getAttributes('link')['href'] as string | undefined;
-    const url = window.prompt('Enter link URL:', prev ?? '');
+    const url = window.prompt(this._transloco.translate('blog.editor.linkPrompt'), prev ?? '');
     if (url === null) return;
     if (url === '') {
       this.editor?.chain().focus().extendMarkRange('link').unsetLink().run();

--- a/src/app/features/blog/models/blog.model.ts
+++ b/src/app/features/blog/models/blog.model.ts
@@ -27,25 +27,25 @@ export const TAG_COLORS: Record<TagColor, { bg: string; fg: string }> = {
 };
 
 export const VEHICLE_ENTRY_CATEGORIES: { value: VehicleEntryCategory; label: string }[] = [
-  { value: 'REPAIR',        label: 'Repair' },
-  { value: 'SERVICE_VISIT', label: 'Service visit' },
-  { value: 'TRIP',          label: 'Trip' },
-  { value: 'FUEL',          label: 'Fuel' },
-  { value: 'UPGRADE',       label: 'Upgrade' },
-  { value: 'INSPECTION',    label: 'Inspection' },
-  { value: 'BREAKDOWN',     label: 'Breakdown' },
-  { value: 'OTHER',         label: 'Other' },
+  { value: 'REPAIR',        label: 'blog.vehicleCategories.repair' },
+  { value: 'SERVICE_VISIT', label: 'blog.vehicleCategories.service_visit' },
+  { value: 'TRIP',          label: 'blog.vehicleCategories.trip' },
+  { value: 'FUEL',          label: 'blog.vehicleCategories.fuel' },
+  { value: 'UPGRADE',       label: 'blog.vehicleCategories.upgrade' },
+  { value: 'INSPECTION',    label: 'blog.vehicleCategories.inspection' },
+  { value: 'BREAKDOWN',     label: 'blog.vehicleCategories.breakdown' },
+  { value: 'OTHER',         label: 'blog.vehicleCategories.other' },
 ];
 
 export const VEHICLE_ENTRY_CATEGORY_LABELS: Record<VehicleEntryCategory, string> = {
-  REPAIR:        'Repair',
-  SERVICE_VISIT: 'Service visit',
-  TRIP:          'Trip',
-  FUEL:          'Fuel',
-  UPGRADE:       'Upgrade',
-  INSPECTION:    'Inspection',
-  BREAKDOWN:     'Breakdown',
-  OTHER:         'Other',
+  REPAIR:        'blog.vehicleCategories.repair',
+  SERVICE_VISIT: 'blog.vehicleCategories.service_visit',
+  TRIP:          'blog.vehicleCategories.trip',
+  FUEL:          'blog.vehicleCategories.fuel',
+  UPGRADE:       'blog.vehicleCategories.upgrade',
+  INSPECTION:    'blog.vehicleCategories.inspection',
+  BREAKDOWN:     'blog.vehicleCategories.breakdown',
+  OTHER:         'blog.vehicleCategories.other',
 };
 
 // Categories shown inline in the chip filter; the rest appear under "More"

--- a/src/app/features/cars/car-sharing/share-vehicle-panel.component.html
+++ b/src/app/features/cars/car-sharing/share-vehicle-panel.component.html
@@ -4,8 +4,8 @@
   <!-- Header -->
   <div class="svp-header">
     <div class="svp-header-text">
-      <h2 class="svp-title">Share vehicle</h2>
-      <p class="svp-subtitle">Manage who can access {{ carName }}</p>
+      <h2 class="svp-title">{{ 'cars.details.shareVehicle' | transloco }}</h2>
+      <p class="svp-subtitle">{{ 'cars.shareVehicle.subtitle' | transloco:{ name: carName } }}</p>
     </div>
     <button class="svp-close" (click)="close()">
       <ion-icon name="close-outline"></ion-icon>
@@ -14,18 +14,18 @@
 
   <!-- Invite -->
   <div class="svp-section">
-    <p class="svp-section-label">Invite user</p>
+    <p class="svp-section-label">{{ 'cars.shareVehicle.inviteUser' | transloco }}</p>
     <div class="svp-invite-row">
       <input
         class="svp-input"
         type="email"
-        placeholder="Email address"
+        [placeholder]="'cars.shareVehicle.emailAddress' | transloco"
         [(ngModel)]="inviteEmail"
         (keydown.enter)="sendInvite()"
       />
       <select class="svp-select" [(ngModel)]="inviteRole">
         @for (r of roles; track r) {
-          <option [value]="r">{{ r | titlecase }}</option>
+          <option [value]="r">{{ roleLabel(r) }}</option>
         }
       </select>
     </div>
@@ -34,16 +34,16 @@
     }
     <button class="svp-btn-invite" [disabled]="inviting || !inviteEmail.trim()" (click)="sendInvite()">
       <ion-icon name="person-add-outline"></ion-icon>
-      {{ inviting ? 'Sending…' : 'Send invite' }}
+      {{ (inviting ? 'cars.shareVehicle.sending' : 'cars.shareVehicle.sendInvite') | transloco }}
     </button>
   </div>
 
   <!-- People with access -->
   <div class="svp-section">
-    <p class="svp-section-label">People with access</p>
+    <p class="svp-section-label">{{ 'cars.shareVehicle.peopleWithAccess' | transloco }}</p>
 
     @if (loading) {
-      <div class="svp-loading">Loading…</div>
+      <div class="svp-loading">{{ 'common.loading' | transloco }}</div>
     } @else {
       <ul class="svp-list">
         @for (entry of entries; track entry.id) {
@@ -56,16 +56,16 @@
             </div>
 
             @if (isOwner(entry)) {
-              <span class="svp-badge svp-badge--owner">Owner</span>
+              <span class="svp-badge svp-badge--owner">{{ 'cars.shareVehicle.roles.owner' | transloco }}</span>
             } @else if (isPending(entry)) {
-              <span class="svp-badge svp-badge--pending">Pending</span>
+              <span class="svp-badge svp-badge--pending">{{ 'cars.shareVehicle.pending' | transloco }}</span>
             } @else {
               <select
                 class="svp-role-select"
                 [ngModel]="entry.role"
                 (ngModelChange)="changeRole(entry, $event)">
                 @for (r of roles; track r) {
-                  <option [value]="r">{{ r | titlecase }}</option>
+                  <option [value]="r">{{ roleLabel(r) }}</option>
                 }
               </select>
             }

--- a/src/app/features/cars/car-sharing/share-vehicle-panel.component.ts
+++ b/src/app/features/cars/car-sharing/share-vehicle-panel.component.ts
@@ -1,4 +1,3 @@
-import { TitleCasePipe } from '@angular/common';
 import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { CarAccessDto, CarAccessRole } from '@hau/autogenapi/models';
@@ -6,12 +5,13 @@ import { CarAccessService } from '@hau/autogenapi/services';
 import { IonIcon } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
 import { closeOutline, personAddOutline, shareOutline, trashOutline } from 'ionicons/icons';
+import { TranslocoPipe, TranslocoService } from '@ngneat/transloco';
 
 @Component({
   selector: 'app-share-vehicle-panel',
   templateUrl: './share-vehicle-panel.component.html',
   styleUrls: ['./share-vehicle-panel.component.scss'],
-  imports: [TitleCasePipe, FormsModule, IonIcon],
+  imports: [FormsModule, IonIcon, TranslocoPipe],
 })
 export class ShareVehiclePanelComponent implements OnChanges {
   @Input() carId!: number;
@@ -27,8 +27,15 @@ export class ShareVehiclePanelComponent implements OnChanges {
 
   readonly roles: CarAccessRole[] = ['FULL', 'USER', 'MAINTENANCE', 'VIEWER'];
 
-  constructor(private readonly carAccessService: CarAccessService) {
+  constructor(
+    private readonly carAccessService: CarAccessService,
+    private readonly _transloco: TranslocoService,
+  ) {
     addIcons({ closeOutline, personAddOutline, shareOutline, trashOutline });
+  }
+
+  roleLabel(role: CarAccessRole): string {
+    return this._transloco.translate(`cars.shareVehicle.roles.${role.toLowerCase()}`);
   }
 
   ngOnChanges(): void {
@@ -57,7 +64,7 @@ export class ShareVehiclePanelComponent implements OnChanges {
         this.inviting = false;
       },
       error: (err) => {
-        this.error = err?.error?.message ?? 'Could not send invitation.';
+        this.error = err?.error?.message ?? this._transloco.translate('cars.shareVehicle.inviteError');
         this.inviting = false;
       },
     });

--- a/src/app/features/cars/cars-details/cars-details.component.html
+++ b/src/app/features/cars/cars-details/cars-details.component.html
@@ -9,20 +9,20 @@
 
       <div class="vd-inner">
         <nav class="vd-breadcrumb">
-          <span class="bc-link" (click)="navigateToGarage()">Garage</span>
+          <span class="bc-link" (click)="navigateToGarage()">{{ 'cars.details.breadcrumb.garage' | transloco }}</span>
           <span class="bc-sep">/</span>
-          <span class="bc-active">Former vehicles</span>
+          <span class="bc-active">{{ 'cars.details.breadcrumb.formerVehicles' | transloco }}</span>
         </nav>
 
         <div class="sv-header">
           <div class="sv-sold-badge">
             <ion-icon name="checkmark-circle-outline"></ion-icon>
-            Sold
+            {{ 'cars.list.sold' | transloco }}
           </div>
           <h1 class="sv-title">{{ car.make }} {{ car.model }}</h1>
           <p class="sv-subtitle">{{ car.year }} · {{ car.license_plate }}</p>
           @if (car.sold_at) {
-            <p class="sv-archived-note">Archived on {{ formatDate(car.sold_at) }}</p>
+            <p class="sv-archived-note">{{ 'cars.details.archivedOn' | transloco:{ date: formatDate(car.sold_at) } }}</p>
           }
         </div>
 
@@ -36,45 +36,45 @@
           </div>
 
           <div class="vd-card sv-details">
-            <h2 class="vd-section-title">Vehicle details</h2>
+            <h2 class="vd-section-title">{{ 'cars.details.vehicleDetails' | transloco }}</h2>
             <div class="vd-fields-grid">
               <div class="vd-field">
-                <span class="vd-field-label">Make</span>
+                <span class="vd-field-label">{{ 'cars.details.fields.make' | transloco }}</span>
                 <div class="vd-field-value">{{ car.make || '—' }}</div>
               </div>
               <div class="vd-field">
-                <span class="vd-field-label">Model</span>
+                <span class="vd-field-label">{{ 'cars.details.fields.model' | transloco }}</span>
                 <div class="vd-field-value">{{ car.model || '—' }}</div>
               </div>
               <div class="vd-field">
-                <span class="vd-field-label">Year</span>
+                <span class="vd-field-label">{{ 'cars.details.fields.year' | transloco }}</span>
                 <div class="vd-field-value">{{ car.year || '—' }}</div>
               </div>
               <div class="vd-field">
-                <span class="vd-field-label">License plate</span>
+                <span class="vd-field-label">{{ 'car.licensePlate' | transloco }}</span>
                 <div class="vd-field-value">{{ car.license_plate || '—' }}</div>
               </div>
               @if (car.vin) {
                 <div class="vd-field vd-field--wide">
-                  <span class="vd-field-label">VIN</span>
+                  <span class="vd-field-label">{{ 'cars.details.fields.vin' | transloco }}</span>
                   <div class="vd-field-value vd-field-value--mono">{{ car.vin }}</div>
                 </div>
               }
               @if (car.current_mileage) {
                 <div class="vd-field">
-                  <span class="vd-field-label">Final mileage</span>
+                  <span class="vd-field-label">{{ 'cars.details.fields.finalMileage' | transloco }}</span>
                   <div class="vd-field-value">{{ formatMileage(car.current_mileage) }}</div>
                 </div>
               }
               @if (car.ownership_start_date) {
                 <div class="vd-field">
-                  <span class="vd-field-label">Owned since</span>
+                  <span class="vd-field-label">{{ 'cars.details.fields.ownedSince' | transloco }}</span>
                   <div class="vd-field-value">{{ formatDate(car.ownership_start_date) }}</div>
                 </div>
               }
               @if (car.fuel_type) {
                 <div class="vd-field">
-                  <span class="vd-field-label">Fuel type</span>
+                  <span class="vd-field-label">{{ 'cars.details.fields.fuelType' | transloco }}</span>
                   <div class="vd-field-value">{{ getFuelLabel(car.fuel_type) }}</div>
                 </div>
               }
@@ -86,7 +86,7 @@
         <div class="sv-footer">
           <button class="btn-remove-garage" (click)="removePanelOpen = true">
             <ion-icon name="log-out-outline"></ion-icon>
-            Remove from archive
+            {{ 'cars.details.removeFromArchive' | transloco }}
           </button>
         </div>
 
@@ -112,25 +112,25 @@
 
       <!-- ── Breadcrumb ──────────────────────────────────────────────────── -->
       <nav class="vd-breadcrumb">
-        <span class="bc-link" (click)="navigateToGarage()">Garage</span>
+        <span class="bc-link" (click)="navigateToGarage()">{{ 'cars.details.breadcrumb.garage' | transloco }}</span>
         <span class="bc-sep">/</span>
         <span class="bc-link" (click)="navigateToGarage()">{{ car.make }} {{ car.model }}</span>
         <span class="bc-sep">/</span>
-        <span class="bc-active">View details</span>
+        <span class="bc-active">{{ 'cars.details.breadcrumb.viewDetails' | transloco }}</span>
       </nav>
 
       <!-- ── Page header ─────────────────────────────────────────── -->
       <div class="vd-page-header">
         <div class="vd-title-block">
           <h1 class="vd-title">{{ car.make }} {{ car.model }}</h1>
-          <p class="vd-subtitle">Complete vehicle profile, documents, deadlines, and maintenance history.</p>
+          <p class="vd-subtitle">{{ 'cars.details.subtitle' | transloco }}</p>
         </div>
         @if (effectiveRole$ | async; as role) {
           <div class="vd-header-actions">
             @if (role === 'OWNER' || role === 'FULL' || role === 'USER') {
               <button class="btn-primary" (click)="navigateToEdit(car)">
                 <ion-icon name="pencil-outline"></ion-icon>
-                Edit vehicle
+                {{ 'cars.details.editVehicle' | transloco }}
               </button>
             }
             <!-- Desktop: all secondary buttons inline -->
@@ -138,23 +138,23 @@
               @if (role === 'OWNER') {
                 <button class="btn-secondary" (click)="sharePanelOpen = true">
                   <ion-icon name="share-outline"></ion-icon>
-                  Share vehicle
+                  {{ 'cars.details.shareVehicle' | transloco }}
                 </button>
               }
               @if (role !== 'VIEWER') {
                 <button class="btn-secondary">
                   <ion-icon name="add-circle-outline"></ion-icon>
-                  Add maintenance
+                  {{ 'cars.details.addMaintenance' | transloco }}
                 </button>
                 <button class="btn-secondary">
                   <ion-icon name="cloud-upload-outline"></ion-icon>
-                  Upload document
+                  {{ 'cars.details.uploadDocument' | transloco }}
                 </button>
               }
               @if (role !== 'OWNER') {
                 <button class="btn-secondary btn-danger">
                   <ion-icon name="exit-outline"></ion-icon>
-                  Remove access
+                  {{ 'cars.details.removeAccess' | transloco }}
                 </button>
               }
             </div>
@@ -169,7 +169,7 @@
             <div class="vd-sheet-backdrop" (click)="moreMenuOpen = false"></div>
             <div class="vd-action-sheet">
               <div class="vd-sheet-handle"></div>
-              <p class="vd-sheet-title">Actions</p>
+              <p class="vd-sheet-title">{{ 'common.actions' | transloco }}</p>
 
               @if (role === 'OWNER') {
                 <button class="vd-sheet-item" (click)="sharePanelOpen = true; moreMenuOpen = false">
@@ -177,8 +177,8 @@
                     <ion-icon name="share-outline"></ion-icon>
                   </div>
                   <div class="vd-sheet-label">
-                    <span class="vd-sheet-item-title">Share vehicle</span>
-                    <span class="vd-sheet-item-desc">Invite others to view or manage</span>
+                    <span class="vd-sheet-item-title">{{ 'cars.details.shareVehicle' | transloco }}</span>
+                    <span class="vd-sheet-item-desc">{{ 'cars.details.sheet.shareVehicleDesc' | transloco }}</span>
                   </div>
                   <ion-icon name="chevron-forward" class="vd-sheet-chevron"></ion-icon>
                 </button>
@@ -190,8 +190,8 @@
                     <ion-icon name="add-circle-outline"></ion-icon>
                   </div>
                   <div class="vd-sheet-label">
-                    <span class="vd-sheet-item-title">Add maintenance</span>
-                    <span class="vd-sheet-item-desc">Log a service or repair record</span>
+                    <span class="vd-sheet-item-title">{{ 'cars.details.addMaintenance' | transloco }}</span>
+                    <span class="vd-sheet-item-desc">{{ 'cars.details.sheet.addMaintenanceDesc' | transloco }}</span>
                   </div>
                   <ion-icon name="chevron-forward" class="vd-sheet-chevron"></ion-icon>
                 </button>
@@ -200,8 +200,8 @@
                     <ion-icon name="cloud-upload-outline"></ion-icon>
                   </div>
                   <div class="vd-sheet-label">
-                    <span class="vd-sheet-item-title">Upload document</span>
-                    <span class="vd-sheet-item-desc">Add RCA, ITP or other documents</span>
+                    <span class="vd-sheet-item-title">{{ 'cars.details.uploadDocument' | transloco }}</span>
+                    <span class="vd-sheet-item-desc">{{ 'cars.details.sheet.uploadDocumentDesc' | transloco }}</span>
                   </div>
                   <ion-icon name="chevron-forward" class="vd-sheet-chevron"></ion-icon>
                 </button>
@@ -213,14 +213,14 @@
                     <ion-icon name="exit-outline"></ion-icon>
                   </div>
                   <div class="vd-sheet-label">
-                    <span class="vd-sheet-item-title">Remove access</span>
-                    <span class="vd-sheet-item-desc">Leave this shared vehicle</span>
+                    <span class="vd-sheet-item-title">{{ 'cars.details.removeAccess' | transloco }}</span>
+                    <span class="vd-sheet-item-desc">{{ 'cars.details.sheet.removeAccessDesc' | transloco }}</span>
                   </div>
                   <ion-icon name="chevron-forward" class="vd-sheet-chevron"></ion-icon>
                 </button>
               }
 
-              <button class="vd-sheet-cancel" (click)="moreMenuOpen = false">Cancel</button>
+              <button class="vd-sheet-cancel" (click)="moreMenuOpen = false">{{ 'common.cancel' | transloco }}</button>
             </div>
           }
         }
@@ -231,25 +231,25 @@
 
         <!-- Vehicle overview card -->
         <div class="vd-card vd-overview-card">
-          <h2 class="vd-section-title">Vehicle overview</h2>
+          <h2 class="vd-section-title">{{ 'cars.details.vehicleOverview' | transloco }}</h2>
 
           <div class="vd-fields-grid">
             <div class="vd-field">
-              <span class="vd-field-label">Make</span>
+              <span class="vd-field-label">{{ 'cars.details.fields.make' | transloco }}</span>
               <div class="vd-field-value">
                 <ion-icon name="car-outline" class="field-icon"></ion-icon>
                 {{ car.make || '—' }}
               </div>
             </div>
             <div class="vd-field">
-              <span class="vd-field-label">Model</span>
+              <span class="vd-field-label">{{ 'cars.details.fields.model' | transloco }}</span>
               <div class="vd-field-value">
                 <ion-icon name="car-outline" class="field-icon"></ion-icon>
                 {{ car.model || '—' }}
               </div>
             </div>
             <div class="vd-field">
-              <span class="vd-field-label">Variant / Trim</span>
+              <span class="vd-field-label">{{ 'cars.details.fields.variant' | transloco }}</span>
               <div class="vd-field-value">
                 <ion-icon name="car-outline" class="field-icon"></ion-icon>
                 {{ car.variant || '—' }}
@@ -257,21 +257,21 @@
             </div>
 
             <div class="vd-field">
-              <span class="vd-field-label">License plate</span>
+              <span class="vd-field-label">{{ 'car.licensePlate' | transloco }}</span>
               <div class="vd-field-value">
                 <ion-icon name="documents-outline" class="field-icon"></ion-icon>
                 {{ car.license_plate || '—' }}
               </div>
             </div>
             <div class="vd-field">
-              <span class="vd-field-label">VIN</span>
+              <span class="vd-field-label">{{ 'cars.details.fields.vin' | transloco }}</span>
               <div class="vd-field-value vd-field-value--mono">
                 <ion-icon name="key-outline" class="field-icon"></ion-icon>
                 {{ car.vin || '—' }}
               </div>
             </div>
             <div class="vd-field">
-              <span class="vd-field-label">Year</span>
+              <span class="vd-field-label">{{ 'cars.details.fields.year' | transloco }}</span>
               <div class="vd-field-value">
                 <ion-icon name="calendar-outline" class="field-icon"></ion-icon>
                 {{ car.year || '—' }}
@@ -279,21 +279,21 @@
             </div>
 
             <div class="vd-field">
-              <span class="vd-field-label">Fuel type</span>
+              <span class="vd-field-label">{{ 'cars.details.fields.fuelType' | transloco }}</span>
               <div class="vd-field-value">
                 <ion-icon name="flame-outline" class="field-icon"></ion-icon>
                 {{ getFuelLabel(car.fuel_type) }}
               </div>
             </div>
             <div class="vd-field">
-              <span class="vd-field-label">Transmission</span>
+              <span class="vd-field-label">{{ 'cars.details.fields.transmission' | transloco }}</span>
               <div class="vd-field-value">
                 <ion-icon name="settings-outline" class="field-icon"></ion-icon>
                 {{ getTransmissionLabel(car.transmission) }}
               </div>
             </div>
             <div class="vd-field">
-              <span class="vd-field-label">Current mileage</span>
+              <span class="vd-field-label">{{ 'car.fields.currentMileage' | transloco }}</span>
               <div class="vd-field-value">
                 <ion-icon name="speedometer-outline" class="field-icon"></ion-icon>
                 {{ formatMileage(car.current_mileage) }}
@@ -301,7 +301,7 @@
             </div>
 
             <div class="vd-field vd-field--wide">
-              <span class="vd-field-label">Ownership start date</span>
+              <span class="vd-field-label">{{ 'cars.details.fields.ownershipStartDate' | transloco }}</span>
               <div class="vd-field-value">
                 <ion-icon name="calendar-outline" class="field-icon"></ion-icon>
                 {{ formatDate(car.ownership_start_date) }}
@@ -314,7 +314,7 @@
             <div class="qs-item">
               <ion-icon name="water-outline" class="qs-icon"></ion-icon>
               <div class="qs-body">
-                <span class="qs-label">Last oil service</span>
+                <span class="qs-label">{{ 'car.fields.lastOilService' | transloco }}</span>
                 <strong class="qs-value">{{ formatDate(car.last_oil_service_date) }}</strong>
               </div>
             </div>
@@ -322,7 +322,7 @@
             <div class="qs-item">
               <ion-icon name="speedometer-outline" class="qs-icon"></ion-icon>
               <div class="qs-body">
-                <span class="qs-label">Current mileage</span>
+                <span class="qs-label">{{ 'car.fields.initialMileage' | transloco }}</span>
                 <strong class="qs-value">{{ formatMileage(car.current_mileage) }}</strong>
               </div>
             </div>
@@ -330,7 +330,7 @@
             <div class="qs-item">
               <ion-icon name="key-outline" class="qs-icon"></ion-icon>
               <div class="qs-body">
-                <span class="qs-label">Next key expiry</span>
+                <span class="qs-label">{{ 'cars.details.nextKeyExpiry' | transloco }}</span>
                 @if (getNextExpiry(docs); as exp) {
                   <strong class="qs-value" [class.qs-value--warning]="exp.warning">
                     {{ exp.label }} {{ exp.days }}d
@@ -359,19 +359,19 @@
               @if (getDocExpiry(docs, 'RCA'); as rcaExpiry) {
                 <span class="doc-chip doc-chip--rca">
                   <ion-icon name="shield-checkmark-outline"></ion-icon>
-                  RCA {{ daysUntil(rcaExpiry) }}d
+                  {{ 'car.documents.insurance.label' | transloco }} {{ daysUntil(rcaExpiry) }}d
                 </span>
               }
               @if (getDocExpiry(docs, 'ITP'); as itpExpiry) {
                 <span class="doc-chip doc-chip--itp">
                   <ion-icon name="build-outline"></ion-icon>
-                  ITP {{ daysUntil(itpExpiry) }}d
+                  {{ 'car.documents.technicalInspection.label' | transloco }} {{ daysUntil(itpExpiry) }}d
                 </span>
               }
               @if (getDocExpiry(docs, 'ROV'); as rovExpiry) {
                 <span class="doc-chip doc-chip--rov">
                   <ion-icon name="car-outline"></ion-icon>
-                  ROV {{ daysUntil(rovExpiry) }}d
+                  {{ 'car.documents.vignette.label' | transloco }} {{ daysUntil(rovExpiry) }}d
                 </span>
               }
             </div>
@@ -380,7 +380,7 @@
               @if (car.last_oil_service_date || car.last_oil_service_mileage) {
                 <div class="pm-row">
                   <ion-icon name="water-outline" class="pm-icon"></ion-icon>
-                  <span class="pm-label">Oil service</span>
+                  <span class="pm-label">{{ 'car.fields.oilService' | transloco }}</span>
                   <span class="pm-value">
                     {{ formatDate(car.last_oil_service_date) }}
                     @if (car.last_oil_service_mileage) {
@@ -392,13 +392,13 @@
               @if (car.ownership_start_date) {
                 <div class="pm-row">
                   <ion-icon name="calendar-outline" class="pm-icon"></ion-icon>
-                  <span class="pm-label">Ownership since</span>
+                  <span class="pm-label">{{ 'car.fields.ownershipSince' | transloco }}</span>
                   <span class="pm-value">{{ formatDate(car.ownership_start_date) }}</span>
                 </div>
               }
               <div class="pm-row">
                 <ion-icon name="speedometer-outline" class="pm-icon"></ion-icon>
-                <span class="pm-label">Current mileage</span>
+                <span class="pm-label">{{ 'car.fields.currentMileage' | transloco }}</span>
                 <span class="pm-value">{{ formatMileage(car.current_mileage) }}</span>
               </div>
             </div>
@@ -409,7 +409,7 @@
 
       <!-- ── Documents & deadlines ───────────────────────────────── -->
       <div class="vd-card">
-        <h2 class="vd-section-title">Documents &amp; deadlines</h2>
+        <h2 class="vd-section-title">{{ 'cars.details.documentsAndDeadlines' | transloco }}</h2>
         <div class="vd-docs-grid">
 
           @if (getDocExpiry(docs, 'RCA'); as rcaExpiry) {
@@ -418,9 +418,9 @@
                 <ion-icon name="shield-checkmark-outline"></ion-icon>
               </div>
               <div class="doc-item-body">
-                <span class="doc-item-label">RCA expiry date</span>
+                <span class="doc-item-label">{{ 'cars.details.docItem.insuranceExpiry' | transloco }}</span>
                 <strong class="doc-item-value">{{ formatDate(rcaExpiry) }}</strong>
-                <span class="doc-item-days">{{ daysUntil(rcaExpiry) }}d left</span>
+                <span class="doc-item-days">{{ 'cars.details.docItem.daysLeft' | transloco:{ days: daysUntil(rcaExpiry) } }}</span>
               </div>
             </div>
           }
@@ -431,9 +431,9 @@
                 <ion-icon name="build-outline"></ion-icon>
               </div>
               <div class="doc-item-body">
-                <span class="doc-item-label">ITP expiry date</span>
+                <span class="doc-item-label">{{ 'cars.details.docItem.inspectionExpiry' | transloco }}</span>
                 <strong class="doc-item-value">{{ formatDate(itpExpiry) }}</strong>
-                <span class="doc-item-days">{{ daysUntil(itpExpiry) }}d left</span>
+                <span class="doc-item-days">{{ 'cars.details.docItem.daysLeft' | transloco:{ days: daysUntil(itpExpiry) } }}</span>
               </div>
             </div>
           }
@@ -444,9 +444,9 @@
                 <ion-icon name="car-outline"></ion-icon>
               </div>
               <div class="doc-item-body">
-                <span class="doc-item-label">ROV expiry date</span>
+                <span class="doc-item-label">{{ 'cars.details.docItem.vignetteExpiry' | transloco }}</span>
                 <strong class="doc-item-value">{{ formatDate(rovExpiry) }}</strong>
-                <span class="doc-item-days">{{ daysUntil(rovExpiry) }}d left</span>
+                <span class="doc-item-days">{{ 'cars.details.docItem.daysLeft' | transloco:{ days: daysUntil(rovExpiry) } }}</span>
               </div>
             </div>
           }
@@ -457,7 +457,7 @@
                 <ion-icon name="water-outline"></ion-icon>
               </div>
               <div class="doc-item-body">
-                <span class="doc-item-label">Last oil service date</span>
+                <span class="doc-item-label">{{ 'car.fields.lastOilServiceDate' | transloco }}</span>
                 <strong class="doc-item-value">{{ formatDate(car.last_oil_service_date) }}</strong>
               </div>
             </div>
@@ -469,7 +469,7 @@
                 <ion-icon name="speedometer-outline"></ion-icon>
               </div>
               <div class="doc-item-body">
-                <span class="doc-item-label">Last oil service mileage</span>
+                <span class="doc-item-label">{{ 'car.fields.lastOilServiceMileage' | transloco }}</span>
                 <strong class="doc-item-value">{{ formatMileage(car.last_oil_service_mileage) }}</strong>
               </div>
             </div>
@@ -481,35 +481,35 @@
       <!-- ── Repairs & maintenance history ──────────────────────── -->
       @if (maintenanceRecords$ | async; as records) {
         <div class="vd-card">
-          <h2 class="vd-section-title">Repairs &amp; maintenance history</h2>
+          <h2 class="vd-section-title">{{ 'cars.details.maintenanceHistory.title' | transloco }}</h2>
 
           <!-- Summary stats -->
           <div class="maint-stats">
             <div class="ms-item">
               <ion-icon name="documents-outline" class="ms-icon ms-icon--blue"></ion-icon>
               <div class="ms-body">
-                <span class="ms-label">Total records</span>
+                <span class="ms-label">{{ 'cars.details.maintenanceHistory.totalRecords' | transloco }}</span>
                 <strong class="ms-value">{{ records.length }}</strong>
               </div>
             </div>
             <div class="ms-item">
               <ion-icon name="color-filter-outline" class="ms-icon ms-icon--green"></ion-icon>
               <div class="ms-body">
-                <span class="ms-label">Total spent</span>
+                <span class="ms-label">{{ 'cars.details.maintenanceHistory.totalSpent' | transloco }}</span>
                 <strong class="ms-value">{{ getTotalSpent(records) | number }} RON</strong>
               </div>
             </div>
             <div class="ms-item">
               <ion-icon name="calendar-outline" class="ms-icon ms-icon--blue"></ion-icon>
               <div class="ms-body">
-                <span class="ms-label">Last service</span>
+                <span class="ms-label">{{ 'cars.details.maintenanceHistory.lastService' | transloco }}</span>
                 <strong class="ms-value">{{ getLastService(records) }}</strong>
               </div>
             </div>
             <div class="ms-item">
               <ion-icon name="speedometer-outline" class="ms-icon ms-icon--teal"></ion-icon>
               <div class="ms-body">
-                <span class="ms-label">Next oil service</span>
+                <span class="ms-label">{{ 'cars.details.maintenanceHistory.nextOilService' | transloco }}</span>
                 <strong class="ms-value">{{ formatMileage(getNextOilService(car)) }}</strong>
               </div>
             </div>
@@ -549,12 +549,12 @@
               <table class="maint-table">
                 <thead>
                   <tr>
-                    <th>Date</th>
-                    <th>Mileage</th>
-                    <th>Category</th>
-                    <th>Work performed</th>
-                    <th>Cost</th>
-                    <th>Notes</th>
+                    <th>{{ 'cars.details.maintenanceHistory.table.date' | transloco }}</th>
+                    <th>{{ 'cars.details.maintenanceHistory.table.mileage' | transloco }}</th>
+                    <th>{{ 'cars.details.maintenanceHistory.table.category' | transloco }}</th>
+                    <th>{{ 'cars.details.maintenanceHistory.table.workPerformed' | transloco }}</th>
+                    <th>{{ 'cars.details.maintenanceHistory.table.cost' | transloco }}</th>
+                    <th>{{ 'cars.details.maintenanceHistory.table.notes' | transloco }}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -578,7 +578,7 @@
           } @else {
             <div class="maint-empty">
               <ion-icon name="construct-outline"></ion-icon>
-              <span>No maintenance records yet</span>
+              <span>{{ 'cars.details.maintenanceHistory.empty' | transloco }}</span>
             </div>
           }
         </div>
@@ -590,7 +590,7 @@
           <div class="vd-remove-row">
             <button class="btn-remove-garage" (click)="removePanelOpen = true">
               <ion-icon name="log-out-outline"></ion-icon>
-              Remove from garage
+              {{ 'cars.details.removeFromGarage' | transloco }}
             </button>
           </div>
         }
@@ -617,18 +617,18 @@
         </div>
         <div class="mr-sheet-rows">
           <div class="mr-sheet-row">
-            <span>Mileage</span>
+            <span>{{ 'cars.details.maintenanceHistory.table.mileage' | transloco }}</span>
             <strong>{{ formatMileage(activeRecord.mileage) }}</strong>
           </div>
           @if (activeRecord.description) {
             <div class="mr-sheet-row">
-              <span>Work performed</span>
+              <span>{{ 'cars.details.maintenanceHistory.table.workPerformed' | transloco }}</span>
               <strong>{{ activeRecord.description }}</strong>
             </div>
           }
           @if (activeRecord.cost != null) {
             <div class="mr-sheet-row">
-              <span>Cost</span>
+              <span>{{ 'cars.details.maintenanceHistory.table.cost' | transloco }}</span>
               <strong>{{ activeRecord.cost | number }} RON</strong>
             </div>
           }

--- a/src/app/features/cars/cars-details/cars-details.component.ts
+++ b/src/app/features/cars/cars-details/cars-details.component.ts
@@ -42,6 +42,7 @@ import {
 } from 'ionicons/icons';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { HAU_ROUTES } from '@hau/app.routes.const';
+import { TranslocoPipe, TranslocoService } from '@ngneat/transloco';
 
 export interface ExpiryInfo {
   label: string;
@@ -54,7 +55,7 @@ export interface ExpiryInfo {
   selector: 'app-cars-details',
   templateUrl: 'cars-details.component.html',
   styleUrls: ['./cars-details.component.scss'],
-  imports: [AsyncPipe, DecimalPipe, NgClass, IonContent, IonIcon, ShareVehiclePanelComponent, RemoveCarPanelComponent, PhotoCarouselComponent],
+  imports: [AsyncPipe, DecimalPipe, NgClass, IonContent, IonIcon, ShareVehiclePanelComponent, RemoveCarPanelComponent, PhotoCarouselComponent, TranslocoPipe],
 })
 export class CarsDetailsComponent implements OnInit {
   readonly currentCar$ = this._carDetailFacade.currentCar$;
@@ -94,6 +95,7 @@ export class CarsDetailsComponent implements OnInit {
     private readonly _navCtrl: NavController,
     private readonly _store: Store,
     private readonly _alertCtrl: AlertController,
+    private readonly _transloco: TranslocoService,
   ) {
     addIcons({
       pencilOutline, addCircleOutline, cloudUploadOutline,
@@ -138,12 +140,12 @@ export class CarsDetailsComponent implements OnInit {
   async onDeletePermanently(car: CarDto): Promise<void> {
     this.removePanelOpen = false;
     const alert = await this._alertCtrl.create({
-      header: 'Delete permanently?',
-      message: `All data for <strong>${car.make} ${car.model}</strong> will be permanently deleted and cannot be recovered.`,
+      header: this._transloco.translate('cars.details.deleteAlert.header'),
+      message: this._transloco.translate('cars.details.deleteAlert.message', { name: `${car.make} ${car.model}` }),
       buttons: [
-        { text: 'Cancel', role: 'cancel' },
+        { text: this._transloco.translate('common.cancel'), role: 'cancel' },
         {
-          text: 'Delete',
+          text: this._transloco.translate('common.delete'),
           role: 'destructive',
           handler: () => this._carDetailFacade.deleteCar(String(car.id)),
         },

--- a/src/app/features/cars/cars-list/cars-list.component.html
+++ b/src/app/features/cars/cars-list/cars-list.component.html
@@ -11,17 +11,17 @@
             class="toggle-btn"
             [class.active]="effectiveViewMode === 'cards'"
             (click)="setViewMode('cards')"
-            aria-label="Cards view">
+            [attr.aria-label]="'cars.list.cardsView' | transloco">
             <ion-icon name="grid-outline"></ion-icon>
-            Cards
+            {{ 'cars.list.cards' | transloco }}
           </button>
           <button
             class="toggle-btn"
             [class.active]="effectiveViewMode === 'list'"
             (click)="setViewMode('list')"
-            aria-label="List view">
+            [attr.aria-label]="'cars.list.listView' | transloco">
             <ion-icon name="list-outline"></ion-icon>
-            List
+            {{ 'cars.list.list' | transloco }}
           </button>
         </div>
       }
@@ -29,7 +29,7 @@
 
     @if (loading$ | async) {
       <div class="loading-state">
-        <ion-label>Loading cars…</ion-label>
+        <ion-label>{{ 'cars.list.loading' | transloco }}</ion-label>
       </div>
     } @else if (((carList$ | async)?.length ?? 0) === 0 && !((sharedCarList$ | async)?.length)) {
 
@@ -39,6 +39,7 @@
         <!-- Left: illustration + CTA -->
         <div class="empty-main">
           <div class="empty-illustration">
+            //todo: move this SVG to a separate file and use <img> for better performance and caching
             <svg viewBox="0 0 480 290" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
               <rect width="480" height="290" rx="18" fill="#eef2fb"/>
               <!-- Clouds -->
@@ -77,71 +78,71 @@
             </svg>
           </div>
 
-          <h2 class="empty-title">Your garage is empty</h2>
-          <p class="empty-desc">Add your first vehicle to start tracking documents, maintenance, and important deadlines.</p>
+          <h2 class="empty-title">{{ 'cars.list.empty.title' | transloco }}</h2>
+          <p class="empty-desc">{{ 'cars.list.empty.description' | transloco }}</p>
 
           <button class="empty-btn-primary" (click)="navigateToAddCar()">
             <ion-icon name="add-circle-outline"></ion-icon>
-            Add your first vehicle
+            {{ 'cars.list.empty.addFirst' | transloco }}
           </button>
 
           <button class="empty-btn-secondary">
             <ion-icon name="help-circle-outline"></ion-icon>
-            How it works
+            {{ 'cars.list.empty.howItWorks' | transloco }}
           </button>
 
-          <p class="empty-hint">You can always add more vehicles later.</p>
+          <p class="empty-hint">{{ 'cars.list.empty.hint' | transloco }}</p>
         </div>
 
         <!-- Right: info cards -->
         <div class="empty-sidebar">
 
           <div class="empty-card">
-            <h3 class="empty-card-title">Getting started</h3>
+            <h3 class="empty-card-title">{{ 'cars.list.empty.gettingStarted.title' | transloco }}</h3>
             <div class="step-item">
               <span class="step-check"><ion-icon name="checkmark-circle"></ion-icon></span>
               <div class="step-text">
-                <strong>Add your vehicle details</strong>
-                <span>Basic info like make, model, and year</span>
+                <strong>{{ 'cars.list.empty.gettingStarted.step1Title' | transloco }}</strong>
+                <span>{{ 'cars.list.empty.gettingStarted.step1Desc' | transloco }}</span>
               </div>
             </div>
             <div class="step-item">
               <span class="step-check"><ion-icon name="checkmark-circle"></ion-icon></span>
               <div class="step-text">
-                <strong>Upload registration and insurance documents</strong>
-                <span>We'll keep them safe and organized</span>
+                <strong>{{ 'cars.list.empty.gettingStarted.step2Title' | transloco }}</strong>
+                <span>{{ 'cars.list.empty.gettingStarted.step2Desc' | transloco }}</span>
               </div>
             </div>
             <div class="step-item">
               <span class="step-check"><ion-icon name="checkmark-circle"></ion-icon></span>
               <div class="step-text">
-                <strong>Set service and inspection dates</strong>
-                <span>Get reminders before it's due</span>
+                <strong>{{ 'cars.list.empty.gettingStarted.step3Title' | transloco }}</strong>
+                <span>{{ 'cars.list.empty.gettingStarted.step3Desc' | transloco }}</span>
               </div>
             </div>
           </div>
 
           <div class="empty-card">
-            <h3 class="empty-card-title">What you unlock</h3>
+            <h3 class="empty-card-title">{{ 'cars.list.empty.unlock.title' | transloco }}</h3>
             <div class="unlock-item">
               <span class="unlock-icon unlock-doc"><ion-icon name="document-text-outline"></ion-icon></span>
               <div class="unlock-text">
-                <strong>Document reminders</strong>
-                <span>Never miss an expiry again</span>
+                <strong>{{ 'cars.list.empty.unlock.docsTitle' | transloco }}</strong>
+                <span>{{ 'cars.list.empty.unlock.docsDesc' | transloco }}</span>
               </div>
             </div>
             <div class="unlock-item">
               <span class="unlock-icon unlock-wrench"><ion-icon name="construct-outline"></ion-icon></span>
               <div class="unlock-text">
-                <strong>Service history</strong>
-                <span>Track all maintenance in one place</span>
+                <strong>{{ 'cars.list.empty.unlock.serviceTitle' | transloco }}</strong>
+                <span>{{ 'cars.list.empty.unlock.serviceDesc' | transloco }}</span>
               </div>
             </div>
             <div class="unlock-item">
               <span class="unlock-icon unlock-cal"><ion-icon name="calendar-outline"></ion-icon></span>
               <div class="unlock-text">
-                <strong>Upcoming deadlines</strong>
-                <span>Stay ahead of important tasks</span>
+                <strong>{{ 'cars.list.empty.unlock.deadlinesTitle' | transloco }}</strong>
+                <span>{{ 'cars.list.empty.unlock.deadlinesDesc' | transloco }}</span>
               </div>
             </div>
           </div>
@@ -149,8 +150,8 @@
           <div class="tip-box">
             <span class="tip-icon"><ion-icon name="information-circle"></ion-icon></span>
             <div class="tip-text">
-              <strong>Tip:</strong> Start with your most-used car and add the rest later.
-              <br><span>You're in control.</span>
+              <strong>{{ 'cars.list.empty.tip.label' | transloco }}</strong> {{ 'cars.list.empty.tip.text' | transloco }}
+              <br><span>{{ 'cars.list.empty.tip.subtext' | transloco }}</span>
             </div>
           </div>
 
@@ -196,7 +197,7 @@
         <div class="shared-section">
           <h3 class="shared-section-title">
             <ion-icon name="share-outline"></ion-icon>
-            Shared with me
+            {{ 'cars.list.sharedWithMe' | transloco }}
           </h3>
 
           @if (effectiveViewMode === 'cards') {
@@ -237,7 +238,7 @@
       <div class="former-section">
         <h3 class="former-section-title">
           <ion-icon name="archive-outline"></ion-icon>
-          Former vehicles
+          {{ 'cars.list.formerVehicles' | transloco }}
         </h3>
         @if (carDocumentsMap$ | async; as docsMap) {
 
@@ -249,7 +250,7 @@
                     [car]="car"
                     [documents]="docsMap[car.id] ?? []">
                   </app-car-list-item>
-                  <span class="former-item-badge">Sold</span>
+                  <span class="former-item-badge">{{ 'cars.list.sold' | transloco }}</span>
                 </div>
               }
             </div>
@@ -261,7 +262,7 @@
                 <app-car-row-item
                   [car]="car"
                   [documents]="docsMap[car.id] ?? []"
-                  badge="Sold"
+                  [badge]="'cars.list.sold' | transloco"
                   (viewClick)="navigateToCarDetails(car)"
                   (editClick)="navigateToCarDetails(car)">
                 </app-car-row-item>

--- a/src/app/features/cars/cars-list/cars-list.component.ts
+++ b/src/app/features/cars/cars-list/cars-list.component.ts
@@ -31,6 +31,7 @@ import {
   listOutline,
   shareOutline,
 } from 'ionicons/icons';
+import { TranslocoPipe } from '@ngneat/transloco';
 
 type ViewMode = 'cards' | 'list';
 const VIEW_MODE_KEY = 'hau_garage_view_mode';
@@ -42,7 +43,7 @@ const VIEW_MODE_KEY = 'hau_garage_view_mode';
   imports: [
     IonFabButton, IonIcon, IonFab, IonLabel, IonList,
     CarsListItemComponent, CarRowItemComponent,
-    AsyncPipe, TitleCasePipe,
+    AsyncPipe, TitleCasePipe, TranslocoPipe,
     IonContent, IonRefresher, IonRefresherContent,
   ],
 })

--- a/src/app/features/cars/component/car-row-item/car-row-item.component.html
+++ b/src/app/features/cars/component/car-row-item/car-row-item.component.html
@@ -25,21 +25,21 @@
         @if (daysUntil(getDocExpiry(documents, 'RCA')) !== null) {
           <div class="doc-pill doc-pill--rca">
             <ion-icon name="shield-checkmark-outline"></ion-icon>
-            <span>RCA</span>
+            <span>{{ 'car.documents.insurance.label' | transloco }}</span>
             <strong>{{ daysUntil(getDocExpiry(documents, 'RCA')) }}d</strong>
           </div>
         }
         @if (daysUntil(getDocExpiry(documents, 'ITP')) !== null) {
           <div class="doc-pill doc-pill--itp">
             <ion-icon name="build-outline"></ion-icon>
-            <span>ITP</span>
+            <span>{{ 'car.documents.technicalInspection.label' | transloco }}</span>
             <strong>{{ daysUntil(getDocExpiry(documents, 'ITP')) }}d</strong>
           </div>
         }
         @if (daysUntil(getDocExpiry(documents, 'ROV')) !== null) {
           <div class="doc-pill doc-pill--rov">
             <ion-icon name="car-outline"></ion-icon>
-            <span>ROV</span>
+            <span>{{ 'car.documents.vignette.label' | transloco }}</span>
             <strong>{{ daysUntil(getDocExpiry(documents, 'ROV')) }}d</strong>
           </div>
         }
@@ -59,11 +59,11 @@
   <ion-item-options side="end">
     <ion-item-option color="primary" (click)="onView()">
       <ion-icon slot="top" name="eye-outline"></ion-icon>
-      View
+      {{ 'common.view' | transloco }}
     </ion-item-option>
     <ion-item-option class="edit-opt" (click)="onEdit()">
       <ion-icon slot="top" name="create-outline"></ion-icon>
-      Edit
+      {{ 'common.edit' | transloco }}
     </ion-item-option>
   </ion-item-options>
 

--- a/src/app/features/cars/component/car-row-item/car-row-item.component.ts
+++ b/src/app/features/cars/component/car-row-item/car-row-item.component.ts
@@ -13,12 +13,13 @@ import {
 } from 'ionicons/icons';
 import { ImageUrlPipe } from '@hau/shared/pipes/image-url.pipe';
 import { daysUntil, getDocExpiry } from '@hau/features/cars/cars.utils';
+import { TranslocoPipe } from '@ngneat/transloco';
 
 @Component({
   selector: 'app-car-row-item',
   templateUrl: 'car-row-item.component.html',
   styleUrls: ['./car-row-item.component.scss'],
-  imports: [IonIcon, IonItem, IonItemOption, IonItemOptions, IonItemSliding, ImageUrlPipe],
+  imports: [IonIcon, IonItem, IonItemOption, IonItemOptions, IonItemSliding, ImageUrlPipe, TranslocoPipe],
 })
 export class CarRowItemComponent {
   @Input({ required: true }) car!: CarDto;

--- a/src/app/features/cars/component/card-list-item/car-list-item.component.html
+++ b/src/app/features/cars/component/card-list-item/car-list-item.component.html
@@ -29,21 +29,21 @@
       @if (daysUntil(getDocExpiry(documents, 'RCA')) !== null) {
         <div class="doc-pill doc-pill--rca">
           <ion-icon name="shield-checkmark-outline"></ion-icon>
-          <span>RCA</span>
+          <span>{{ 'car.documents.insurance.label' | transloco }}</span>
           <strong>{{ daysUntil(getDocExpiry(documents, 'RCA')) }}d</strong>
         </div>
       }
       @if (daysUntil(getDocExpiry(documents, 'ITP')) !== null) {
         <div class="doc-pill doc-pill--itp">
           <ion-icon name="build-outline"></ion-icon>
-          <span>ITP</span>
+          <span>{{ 'car.documents.technicalInspection.label' | transloco }}</span>
           <strong>{{ daysUntil(getDocExpiry(documents, 'ITP')) }}d</strong>
         </div>
       }
       @if (daysUntil(getDocExpiry(documents, 'ROV')) !== null) {
         <div class="doc-pill doc-pill--rov">
           <ion-icon name="car-outline"></ion-icon>
-          <span>ROV</span>
+          <span>{{ 'car.documents.vignette.label' | transloco }}</span>
           <strong>{{ daysUntil(getDocExpiry(documents, 'ROV')) }}d</strong>
         </div>
       }
@@ -56,7 +56,7 @@
       @if (car.last_oil_service_date || car.last_oil_service_mileage) {
         <div class="preview-meta-row">
           <ion-icon name="water-outline" class="meta-icon"></ion-icon>
-          <span class="meta-label">Oil service</span>
+          <span class="meta-label">{{ 'car.fields.oilService' | transloco }}</span>
           <span class="meta-value">
             {{ formatDate(car.last_oil_service_date) }}
             @if (car.last_oil_service_mileage) {
@@ -68,14 +68,14 @@
       @if (car.ownership_start_date) {
         <div class="preview-meta-row">
           <ion-icon name="calendar-outline" class="meta-icon"></ion-icon>
-          <span class="meta-label">Ownership since</span>
+          <span class="meta-label">{{ 'car.fields.ownershipSince' | transloco }}</span>
           <span class="meta-value">{{ formatDate(car.ownership_start_date) }}</span>
         </div>
       }
       @if (car.current_mileage) {
         <div class="preview-meta-row">
           <ion-icon name="speedometer-outline" class="meta-icon"></ion-icon>
-          <span class="meta-label">Initial mileage</span>
+          <span class="meta-label">{{ 'car.fields.initialMileage' | transloco }}</span>
           <span class="meta-value">{{ formatMileage(car.current_mileage) }}</span>
         </div>
       }
@@ -83,11 +83,12 @@
   }
 
   <mat-card-actions class="card-footer">
+    //todo: buttons should have action, currently they are just placeholders.
     <button mat-flat-button color="primary" class="details-button">
       {{ 'car.viewDetails' | transloco }}
     </button>
     <button mat-button class="edit-button">
-      {{ 'car.edit' | transloco }}
+      {{ 'common.edit' | transloco }}
     </button>
   </mat-card-actions>
 

--- a/src/app/features/cars/component/cars-form/cars-form.component.html
+++ b/src/app/features/cars/component/cars-form/cars-form.component.html
@@ -3,15 +3,15 @@
 
     <!-- Breadcrumb -->
     <nav class="breadcrumb">
-      <button class="breadcrumb__link" type="button" (click)="cancel()">Garage</button>
+      <button class="breadcrumb__link" type="button" (click)="cancel()">{{ 'cars.details.breadcrumb.garage' | transloco }}</button>
       <span class="breadcrumb__sep">/</span>
-      <span class="breadcrumb__current">{{ isEditMode ? 'Edit vehicle' : 'Add vehicle' }}</span>
+      <span class="breadcrumb__current">{{ (isEditMode ? 'cars.form.editVehicle' : 'cars.form.addVehicle') | transloco }}</span>
     </nav>
 
     <!-- Page header -->
     <div class="page-header">
-      <h1 class="page-title">{{ isEditMode ? 'Edit vehicle' : 'Add vehicle' }}</h1>
-      <p class="page-subtitle">{{ isEditMode ? 'Update your vehicle details' : 'Add a new car to your garage' }}</p>
+      <h1 class="page-title">{{ (isEditMode ? 'cars.form.editVehicle' : 'cars.form.addVehicle') | transloco }}</h1>
+      <p class="page-subtitle">{{ (isEditMode ? 'cars.form.editSubtitle' : 'cars.form.addSubtitle') | transloco }}</p>
     </div>
 
     <!-- Main grid: sidebar (preview) + form -->
@@ -52,7 +52,7 @@
               @if (form.value.last_oil_service_date || form.value.last_oil_service_mileage) {
                 <div class="preview-meta-row">
                   <ion-icon name="water-outline" class="meta-icon"></ion-icon>
-                  <span class="meta-label">Oil service</span>
+                  <span class="meta-label">{{ 'car.fields.oilService' | transloco }}</span>
                   <span class="meta-value">
                     {{ formatDate(form.value.last_oil_service_date) }}
                     @if (form.value.last_oil_service_mileage) {
@@ -64,14 +64,14 @@
               @if (form.value.ownership_start_date) {
                 <div class="preview-meta-row">
                   <ion-icon name="calendar-outline" class="meta-icon"></ion-icon>
-                  <span class="meta-label">Ownership since</span>
+                  <span class="meta-label">{{ 'car.fields.ownershipSince' | transloco }}</span>
                   <span class="meta-value">{{ formatDate(form.value.ownership_start_date) }}</span>
                 </div>
               }
               @if (form.value.current_mileage) {
                 <div class="preview-meta-row">
                   <ion-icon name="speedometer-outline" class="meta-icon"></ion-icon>
-                  <span class="meta-label">Current mileage</span>
+                  <span class="meta-label">{{ 'car.fields.currentMileage' | transloco }}</span>
                   <span class="meta-value">{{ formatMileage(form.value.current_mileage) }}</span>
                 </div>
               }
@@ -84,27 +84,27 @@
         <div class="quick-tips hau-card">
           <div class="tips-header">
             <ion-icon name="bulb-outline" class="tips-icon"></ion-icon>
-            <span>Quick tips</span>
-            <button type="button" class="tips-close" (click)="dismissQuickTips()" aria-label="Dismiss quick tips">
+            <span>{{ 'cars.form.quickTips.title' | transloco }}</span>
+            <button type="button" class="tips-close" (click)="dismissQuickTips()" [attr.aria-label]="'cars.form.quickTips.dismiss' | transloco">
               <ion-icon name="close-outline"></ion-icon>
             </button>
           </div>
           <ul class="tips-list">
             <li>
               <ion-icon name="checkmark-circle-outline" class="tip-check"></ion-icon>
-              Only the core details are needed to save — expand the sections for more options.
+              {{ 'cars.form.quickTips.tip1' | transloco }}
             </li>
             <li>
               <ion-icon name="checkmark-circle-outline" class="tip-check"></ion-icon>
-              VIN helps us provide accurate maintenance reminders.
+              {{ 'cars.form.quickTips.tip2' | transloco }}
             </li>
             <li>
               <ion-icon name="checkmark-circle-outline" class="tip-check"></ion-icon>
-              Keep your documents up to date to avoid penalties.
+              {{ 'cars.form.quickTips.tip3' | transloco }}
             </li>
             <li>
               <ion-icon name="checkmark-circle-outline" class="tip-check"></ion-icon>
-              You can update any information later from the vehicle details.
+              {{ 'cars.form.quickTips.tip4' | transloco }}
             </li>
           </ul>
         </div>
@@ -118,7 +118,7 @@
 
           <!-- Required: Vehicle details -->
           <div class="form-section">
-            <h3 class="section-title">Vehicle details</h3>
+            <h3 class="section-title">{{ 'cars.details.vehicleDetails' | transloco }}</h3>
 
             <app-vehicle-catalog-select
               [initialMake]="form.value.make"
@@ -128,13 +128,13 @@
             </app-vehicle-catalog-select>
 
             <div class="form-row">
-              <app-form-field label="License plate" formControlName="license_plate"></app-form-field>
-              <app-form-field label="Nickname (optional)" formControlName="nickname"></app-form-field>
+              <app-form-field [label]="'car.licensePlate' | transloco" formControlName="license_plate"></app-form-field>
+              <app-form-field [label]="'cars.form.fields.nickname' | transloco" formControlName="nickname"></app-form-field>
             </div>
 
             <p class="section-note">
               <ion-icon name="information-circle-outline"></ion-icon>
-              These are the core details. Everything else can be added later.
+              {{ 'cars.form.coreDetailsNote' | transloco }}
             </p>
           </div>
 
@@ -142,8 +142,8 @@
           <div class="form-section form-section--collapsible" [class.is-open]="additionalExpanded">
             <button type="button" class="collapsible-trigger" (click)="additionalExpanded = !additionalExpanded">
               <div class="collapsible-trigger__info">
-                <span class="collapsible-trigger__title">Additional vehicle info</span>
-                <span class="collapsible-trigger__desc">Optional details for maintenance, history and reports</span>
+                <span class="collapsible-trigger__title">{{ 'cars.form.additionalInfo.title' | transloco }}</span>
+                <span class="collapsible-trigger__desc">{{ 'cars.form.additionalInfo.desc' | transloco }}</span>
               </div>
               <div class="collapsible-trigger__aside">
                 <span class="collapsible-badge">{{ additionalBadge }}</span>
@@ -156,30 +156,30 @@
                 <div class="collapsible-content">
 
                   <div class="form-row">
-                    <app-form-field label="Variant / Trim" formControlName="variant"></app-form-field>
-                    <app-form-field label="VIN" formControlName="vin"></app-form-field>
+                    <app-form-field [label]="'cars.details.fields.variant' | transloco" formControlName="variant"></app-form-field>
+                    <app-form-field [label]="'cars.details.fields.vin' | transloco" formControlName="vin"></app-form-field>
                   </div>
 
                   <div class="form-row">
                     <app-form-field
                       [controlType]="FormControlType.Dropdown"
-                      label="Fuel type"
+                      [label]="'cars.details.fields.fuelType' | transloco"
                       formControlName="fuel_type"
                       [options]="fuelTypeOptions">
                     </app-form-field>
                     <app-form-field
                       [controlType]="FormControlType.Dropdown"
-                      label="Transmission"
+                      [label]="'cars.details.fields.transmission' | transloco"
                       formControlName="transmission"
                       [options]="transmissionOptions">
                     </app-form-field>
                   </div>
 
                   <div class="form-row">
-                    <app-form-field label="Engine" formControlName="engine"></app-form-field>
+                    <app-form-field [label]="'cars.form.fields.engine' | transloco" formControlName="engine"></app-form-field>
                     <app-form-field
                       [controlType]="FormControlType.Dropdown"
-                      label="Color"
+                      [label]="'cars.form.fields.color' | transloco"
                       formControlName="color"
                       [options]="colorOptions">
                     </app-form-field>
@@ -187,18 +187,18 @@
 
                   <div class="form-row">
                     <div class="mileage-field-wrap">
-                      <app-form-field [inputType]="InputType.Number" label="Initial mileage (km)" formControlName="current_mileage"></app-form-field>
+                      <app-form-field [inputType]="InputType.Number" [label]="'cars.form.fields.initialMileage' | transloco" formControlName="current_mileage"></app-form-field>
                       @if (!form.value.current_mileage) {
                         <p class="mileage-hint">
                           <ion-icon name="information-circle-outline"></ion-icon>
                           <span>
-                            <strong>Initial mileage is recommended.</strong>
-                            It improves maintenance tracking, service reminders, and report accuracy. You can still continue without it.
+                            <strong>{{ 'cars.form.mileageHint.title' | transloco }}</strong>
+                            {{ 'cars.form.mileageHint.desc' | transloco }}
                           </span>
                         </p>
                       }
                     </div>
-                    <app-form-field [controlType]="FormControlType.DatePicker" label="Ownership start date" formControlName="ownership_start_date"></app-form-field>
+                    <app-form-field [controlType]="FormControlType.DatePicker" [label]="'cars.details.fields.ownershipStartDate' | transloco" formControlName="ownership_start_date"></app-form-field>
                   </div>
 
                 </div>
@@ -210,8 +210,8 @@
           <div class="form-section form-section--collapsible" [class.is-open]="documentsExpanded">
             <button type="button" class="collapsible-trigger" (click)="documentsExpanded = !documentsExpanded">
               <div class="collapsible-trigger__info">
-                <span class="collapsible-trigger__title">Documents &amp; deadlines</span>
-                <span class="collapsible-trigger__desc">Oil service tracking — documents are managed in the Documents section</span>
+                <span class="collapsible-trigger__title">{{ 'cars.details.documentsAndDeadlines' | transloco }}</span>
+                <span class="collapsible-trigger__desc">{{ 'cars.form.documentsSection.desc' | transloco }}</span>
               </div>
               <div class="collapsible-trigger__aside">
                 <span class="collapsible-badge">{{ documentsBadge }}</span>
@@ -224,8 +224,8 @@
                 <div class="collapsible-content">
 
                   <div class="form-row">
-                    <app-form-field [controlType]="FormControlType.DatePicker" label="Last oil service date" formControlName="last_oil_service_date"></app-form-field>
-                    <app-form-field [inputType]="InputType.Number" label="Last oil service mileage" formControlName="last_oil_service_mileage"></app-form-field>
+                    <app-form-field [controlType]="FormControlType.DatePicker" [label]="'car.fields.lastOilServiceDate' | transloco" formControlName="last_oil_service_date"></app-form-field>
+                    <app-form-field [inputType]="InputType.Number" [label]="'car.fields.lastOilServiceMileage' | transloco" formControlName="last_oil_service_mileage"></app-form-field>
                   </div>
 
                 </div>
@@ -236,12 +236,12 @@
           <!-- Photos -->
           <div class="form-section">
             <div class="photos-header">
-              <h3 class="section-title">Photos</h3>
+              <h3 class="section-title">{{ 'cars.form.photos.title' | transloco }}</h3>
               <span class="photos-counter" [class.photos-counter--full]="photos.length >= MAX_PHOTOS">
                 {{ photos.length }} / {{ MAX_PHOTOS }}
               </span>
             </div>
-            <p class="section-subtitle">Add photos of your vehicle. Click a photo to set it as default. You can upload more later.</p>
+            <p class="section-subtitle">{{ 'cars.form.photos.subtitle' | transloco }}</p>
 
             <div class="photos-grid">
               @if (photos.length < MAX_PHOTOS) {
@@ -249,7 +249,7 @@
                   [controlType]="FormControlType.File"
                   [multiple]="true"
                   (selectedFiles)="onAddPhotos($event)"
-                  label="Upload photos">
+                  [label]="'cars.form.photos.uploadLabel' | transloco">
                 </app-form-field>
               }
 
@@ -258,10 +258,10 @@
                   class="photo-preview"
                   [class.photo-preview--default]="photo.isDefault"
                   (click)="setDefault($index)"
-                  [attr.title]="photo.isDefault ? 'Default photo' : 'Click to set as default'">
+                  [attr.title]="(photo.isDefault ? 'cars.form.photos.defaultPhoto' : 'cars.form.photos.setAsDefault') | transloco">
                   <img [src]="photo.url | imageUrl" alt="Vehicle photo" />
                   @if (photo.isDefault) {
-                    <span class="default-badge">Default</span>
+                    <span class="default-badge">{{ 'cars.form.photos.defaultBadge' | transloco }}</span>
                   }
                   <button type="button" class="remove-photo" (click)="removePhoto($index, $event)">×</button>
                 </div>
@@ -277,7 +277,7 @@
             @if (photos.length >= MAX_PHOTOS) {
               <p class="photos-error photos-error--limit">
                 <ion-icon name="information-circle-outline"></ion-icon>
-                Maximum of {{ MAX_PHOTOS }} photos reached. Remove a photo to add more.
+                {{ 'cars.form.photos.limitReached' | transloco:{ max: MAX_PHOTOS } }}
               </p>
             }
           </div>
@@ -289,7 +289,7 @@
           <div class="remove-row">
             <button type="button" class="btn-remove-garage" (click)="removePanelOpen = true">
               <ion-icon name="log-out-outline"></ion-icon>
-              Remove from garage
+              {{ 'cars.details.removeFromGarage' | transloco }}
             </button>
           </div>
         }
@@ -315,20 +315,20 @@
     <ion-button class="btn-save" (click)="saveCar()" [disabled]="isSubmitting()">
       @if (isSubmitting()) {
         <ion-spinner name="crescent" slot="start"></ion-spinner>
-        {{ isEditMode ? 'Saving...' : 'Adding...' }}
+        {{ (isEditMode ? 'cars.form.actionBar.saving' : 'cars.form.actionBar.adding') | transloco }}
       } @else {
         <ion-icon slot="start" name="save-outline"></ion-icon>
-        {{ isEditMode ? 'Update vehicle' : 'Save vehicle' }}
+        {{ (isEditMode ? 'cars.form.actionBar.update' : 'cars.form.actionBar.save') | transloco }}
       }
     </ion-button>
 
     @if (!isEditMode) {
       <button type="button" class="btn-add-another" (click)="saveAndAddAnother()" [disabled]="isSubmitting()">
         <ion-icon name="add-circle-outline"></ion-icon>
-        Save &amp; add another
+        {{ 'cars.form.actionBar.saveAndAddAnother' | transloco }}
       </button>
     }
 
-    <button type="button" class="btn-cancel" (click)="cancel()" [disabled]="isSubmitting()">Cancel</button>
+    <button type="button" class="btn-cancel" (click)="cancel()" [disabled]="isSubmitting()">{{ 'common.cancel' | transloco }}</button>
   </div>
 </div>

--- a/src/app/features/cars/component/cars-form/cars-form.component.ts
+++ b/src/app/features/cars/component/cars-form/cars-form.component.ts
@@ -38,6 +38,7 @@ import {
 } from 'ionicons/icons';
 import {CarService} from '@hau/autogenapi/services';
 import {ImageUrlPipe} from '@hau/shared/pipes/image-url.pipe';
+import {TranslocoPipe, TranslocoService} from '@ngneat/transloco';
 
 const QUICK_TIPS_DISMISSED_KEY = 'hau_cars_form_quick_tips_dismissed';
 
@@ -61,7 +62,7 @@ class LicensePlateControl extends FormControl<string | null> {
     selector: 'app-cars-form',
     templateUrl: 'cars-form.component.html',
     styleUrls: ['./cars-form.component.scss'],
-    imports: [FormFieldComponent, IonButton, ReactiveFormsModule, IonContent, IonIcon, IonSpinner, ImageUrlPipe, VehicleCatalogSelectComponent, RemoveCarPanelComponent]
+    imports: [FormFieldComponent, IonButton, ReactiveFormsModule, IonContent, IonIcon, IonSpinner, ImageUrlPipe, VehicleCatalogSelectComponent, RemoveCarPanelComponent, TranslocoPipe]
 })
 export class CarsFormComponent implements OnInit {
   protected readonly InputType = InputType;
@@ -85,12 +86,16 @@ export class CarsFormComponent implements OnInit {
   get additionalBadge(): string {
     const v = this.form.value;
     const filled = [v.variant, v.vin, v.fuel_type, v.transmission, v.engine, v.color, v.current_mileage, v.ownership_start_date].filter(Boolean).length;
-    return filled > 0 ? `${filled} of 8 filled` : '8 optional fields';
+    return filled > 0
+      ? this._transloco.translate('cars.form.additionalBadge.filled', { count: filled, total: 8 })
+      : this._transloco.translate('cars.form.additionalBadge.empty', { total: 8 });
   }
 
   get documentsBadge(): string {
     const v = this.form.value;
-    return (v.last_oil_service_date || v.last_oil_service_mileage) ? 'Oil set' : 'Oil service optional';
+    return this._transloco.translate(
+      (v.last_oil_service_date || v.last_oil_service_mileage) ? 'cars.form.documentsBadge.set' : 'cars.form.documentsBadge.optional',
+    );
   }
 
   @Input() set currentCar(currentCar: CarDto | null | undefined) {
@@ -104,7 +109,8 @@ export class CarsFormComponent implements OnInit {
     private readonly _carFacade: CarDetailsFacade,
     private readonly _carService: CarService,
     private readonly _nav: NavController,
-    private readonly _alertCtrl: AlertController
+    private readonly _alertCtrl: AlertController,
+    private readonly _transloco: TranslocoService
   ) {
     addIcons({
       shieldCheckmarkOutline, buildOutline, carOutline, waterOutline,
@@ -233,16 +239,16 @@ export class CarsFormComponent implements OnInit {
   private async _confirmSaveWithoutMileage(): Promise<boolean> {
     return new Promise(async resolve => {
       const alert = await this._alertCtrl.create({
-        header: 'No mileage entered',
-        message: 'Initial mileage improves maintenance tracking, service reminders, and report accuracy. Do you want to continue without it?',
+        header: this._transloco.translate('cars.form.mileageAlert.header'),
+        message: this._transloco.translate('cars.form.mileageAlert.message'),
         buttons: [
           {
-            text: 'Add mileage',
+            text: this._transloco.translate('cars.form.mileageAlert.addMileage'),
             role: 'cancel',
             handler: () => resolve(false),
           },
           {
-            text: 'Continue without it',
+            text: this._transloco.translate('cars.form.mileageAlert.continueWithoutIt'),
             role: 'confirm',
             handler: () => resolve(true),
           },
@@ -305,14 +311,14 @@ export class CarsFormComponent implements OnInit {
   async onDeletePermanently(): Promise<void> {
     this.removePanelOpen = false;
     const v = this.form.value;
-    const name = [v.make, v.model].filter(Boolean).join(' ') || 'această mașină';
+    const name = [v.make, v.model].filter(Boolean).join(' ') || this._transloco.translate('cars.form.deleteAlert.fallbackName');
     const alert = await this._alertCtrl.create({
-      header: 'Delete permanently?',
-      message: `All data for <strong>${name}</strong> will be permanently deleted and cannot be recovered.`,
+      header: this._transloco.translate('cars.details.deleteAlert.header'),
+      message: this._transloco.translate('cars.details.deleteAlert.message', { name }),
       buttons: [
-        { text: 'Cancel', role: 'cancel' },
+        { text: this._transloco.translate('common.cancel'), role: 'cancel' },
         {
-          text: 'Delete',
+          text: this._transloco.translate('common.delete'),
           role: 'destructive',
           handler: () => this._carFacade.deleteCar(String(v.id)),
         },

--- a/src/app/features/cars/component/document-list-item/document-list-item.component.html
+++ b/src/app/features/cars/component/document-list-item/document-list-item.component.html
@@ -2,9 +2,9 @@
   <ion-card-content>
     <div class="document-content">
       <div class="header">
-        <h2><b>Insurance{{document.document_type}}</b></h2>
-        <h2>Issue date - {{document.issue_date}}</h2>
-        <h3>Expiry date - <b>{{document.expiry_date}}</b></h3>
+        <h2><b>{{ 'car.documents.item.insurance' | transloco }} {{ document.document_type }}</b></h2>
+        <h2>{{ 'car.documents.item.issueDate' | transloco }} - {{ document.issue_date }}</h2>
+        <h3>{{ 'car.documents.item.expiryDate' | transloco }} - <b>{{ document.expiry_date }}</b></h3>
       </div>
     </div>
   </ion-card-content>

--- a/src/app/features/cars/component/document-list-item/document-list-item.component.ts
+++ b/src/app/features/cars/component/document-list-item/document-list-item.component.ts
@@ -1,12 +1,13 @@
 import { Component, Input } from '@angular/core';
 import { DocumentDto } from '@hau/autogenapi/models';
 import { IonCard, IonCardContent } from '@ionic/angular/standalone';
+import { TranslocoPipe } from '@ngneat/transloco';
 
 @Component({
     selector: 'app-document-list-item',
     templateUrl: 'document-list-item.component.html',
     styleUrls: ['./document-list-item.component.scss'],
-    imports: [IonCardContent, IonCard]
+    imports: [IonCardContent, IonCard, TranslocoPipe]
 })
 export class DocumentListItemComponent {
   @Input({ required: true }) document!: DocumentDto;

--- a/src/app/features/cars/remove-car-panel/remove-car-panel.component.html
+++ b/src/app/features/cars/remove-car-panel/remove-car-panel.component.html
@@ -3,8 +3,8 @@
 
     <div class="rcp-header">
       <div class="rcp-header-text">
-        <h2 class="rcp-title">{{ isSold ? 'Manage archived vehicle' : 'Remove from garage' }}</h2>
-        <p class="rcp-subtitle">What do you want to do with <strong>{{ carName }}</strong>?</p>
+        <h2 class="rcp-title">{{ (isSold ? 'cars.removePanel.titleSold' : 'cars.removePanel.titleActive') | transloco }}</h2>
+        <p class="rcp-subtitle" [innerHTML]="'cars.removePanel.subtitle' | transloco:{ name: carName }"></p>
       </div>
       <button class="rcp-close" (click)="closed.emit()">
         <ion-icon name="close-outline"></ion-icon>
@@ -19,8 +19,8 @@
             <ion-icon name="refresh-outline"></ion-icon>
           </div>
           <div class="rcp-option-body">
-            <span class="rcp-option-title">Add back to garage</span>
-            <span class="rcp-option-desc">Restore as an active vehicle. All history preserved.</span>
+            <span class="rcp-option-title">{{ 'cars.removePanel.restore.title' | transloco }}</span>
+            <span class="rcp-option-desc">{{ 'cars.removePanel.restore.desc' | transloco }}</span>
           </div>
           <ion-icon name="chevron-forward-outline" class="rcp-option-arrow"></ion-icon>
         </button>
@@ -30,8 +30,8 @@
             <ion-icon name="checkmark-circle-outline"></ion-icon>
           </div>
           <div class="rcp-option-body">
-            <span class="rcp-option-title">Mark as sold</span>
-            <span class="rcp-option-desc">Archived in Former vehicles. All history preserved, read-only.</span>
+            <span class="rcp-option-title">{{ 'cars.removePanel.markSold.title' | transloco }}</span>
+            <span class="rcp-option-desc">{{ 'cars.removePanel.markSold.desc' | transloco }}</span>
           </div>
           <ion-icon name="chevron-forward-outline" class="rcp-option-arrow"></ion-icon>
         </button>
@@ -42,15 +42,15 @@
           <ion-icon name="trash-outline"></ion-icon>
         </div>
         <div class="rcp-option-body">
-          <span class="rcp-option-title">Delete permanently</span>
-          <span class="rcp-option-desc">All data deleted. This cannot be undone.</span>
+          <span class="rcp-option-title">{{ 'cars.removePanel.deletePermanently.title' | transloco }}</span>
+          <span class="rcp-option-desc">{{ 'cars.removePanel.deletePermanently.desc' | transloco }}</span>
         </div>
         <ion-icon name="chevron-forward-outline" class="rcp-option-arrow"></ion-icon>
       </button>
 
     </div>
 
-    <button class="rcp-cancel" (click)="closed.emit()">Cancel</button>
+    <button class="rcp-cancel" (click)="closed.emit()">{{ 'common.cancel' | transloco }}</button>
 
   </div>
 </div>

--- a/src/app/features/cars/remove-car-panel/remove-car-panel.component.ts
+++ b/src/app/features/cars/remove-car-panel/remove-car-panel.component.ts
@@ -2,12 +2,13 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { IonIcon } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
 import { checkmarkCircleOutline, trashOutline, closeOutline, chevronForwardOutline, refreshOutline } from 'ionicons/icons';
+import { TranslocoPipe } from '@ngneat/transloco';
 
 @Component({
   selector: 'app-remove-car-panel',
   templateUrl: 'remove-car-panel.component.html',
   styleUrls: ['./remove-car-panel.component.scss'],
-  imports: [IonIcon],
+  imports: [IonIcon, TranslocoPipe],
 })
 export class RemoveCarPanelComponent {
   @Input() carName = '';

--- a/src/app/features/cars/state/car-details/car-details.facade.ts
+++ b/src/app/features/cars/state/car-details/car-details.facade.ts
@@ -1,17 +1,17 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { AddCarDto, CarDto, DocumentDto, MaintenanceRecordDto } from '@hau/autogenapi/models';
 import { CarDetailsActions } from '@hau/features/cars/state/car-details/car-details.actions';
 import { CarDetailsState } from '@hau/features/cars/state/car-details/car-details.state';
-import { Select, Store } from '@ngxs/store';
+import { Store } from '@ngxs/store';
 import { Observable } from 'rxjs';
 
 @Injectable()
 export class CarDetailsFacade {
-  @Select(CarDetailsState.currentCar) currentCar$!: Observable<CarDto | null | undefined>;
-  @Select(CarDetailsState.loading) loading$!: Observable<boolean>;
-  @Select(CarDetailsState.submitting) submitting$!: Observable<boolean>;
-  @Select(CarDetailsState.carDocuments) carDocuments$!: Observable<DocumentDto[] | null | undefined>;
-  @Select(CarDetailsState.maintenanceRecords) maintenanceRecords$!: Observable<MaintenanceRecordDto[] | null | undefined>;
+  currentCar$: Observable<CarDto | null | undefined> = inject(Store).select(CarDetailsState.currentCar);
+  loading$: Observable<boolean> = inject(Store).select(CarDetailsState.loading);
+  submitting$: Observable<boolean> = inject(Store).select(CarDetailsState.submitting);
+  carDocuments$: Observable<DocumentDto[] | null | undefined> = inject(Store).select(CarDetailsState.carDocuments);
+  maintenanceRecords$: Observable<MaintenanceRecordDto[] | null | undefined> = inject(Store).select(CarDetailsState.maintenanceRecords);
 
   constructor(private readonly _store: Store) { }
 

--- a/src/app/features/cars/state/car-details/car-details.state.ts
+++ b/src/app/features/cars/state/car-details/car-details.state.ts
@@ -5,6 +5,7 @@ import { CarService, DocumentService, MaintenanceRecordService } from '@hau/auto
 import { CarDetailsActions } from '@hau/features/cars/state/car-details/car-details.actions';
 import { CarListActions } from '@hau/features/cars/state/car-list/car-list.actions';
 import { NavController, ToastController } from '@ionic/angular/standalone';
+import { TranslocoService } from '@ngneat/transloco';
 import { Action, Selector, State, StateContext } from '@ngxs/store';
 import { take } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -53,6 +54,7 @@ export class CarDetailsState {
     private readonly _maintenanceService: MaintenanceRecordService,
     private _navCtrl: NavController,
     private _toastCtrl: ToastController,
+    private readonly _transloco: TranslocoService,
   ) { }
 
   @Selector()
@@ -123,7 +125,7 @@ export class CarDetailsState {
     patchState({ submitting: false });
     dispatch(new CarListActions.InjectCar(car));
     const toast = await this._toastCtrl.create({
-      message: 'Mașina a fost adăugată cu succes!',
+      message: this._transloco.translate('cars.toast.createSuccess'),
       duration: 2500,
       color: 'success',
       position: 'top',
@@ -138,7 +140,7 @@ export class CarDetailsState {
     console.error('Error creating car:', err);
     const message = err?.error?.message
       ? (Array.isArray(err.error.message) ? err.error.message.join(', ') : err.error.message)
-      : 'A apărut o eroare. Încearcă din nou.';
+      : this._transloco.translate('cars.toast.genericError');
     const toast = await this._toastCtrl.create({
       message,
       duration: 4000,
@@ -162,7 +164,7 @@ export class CarDetailsState {
     patchState({ submitting: false, currentCar: { item: car, loading: false } });
     dispatch(new CarListActions.UpdateCarInList(car));
     const toast = await this._toastCtrl.create({
-      message: 'Mașina a fost actualizată cu succes!',
+      message: this._transloco.translate('cars.toast.updateSuccess'),
       duration: 2500,
       color: 'success',
       position: 'top',
@@ -177,7 +179,7 @@ export class CarDetailsState {
     console.error('Error updating car:', err);
     const message = err?.error?.message
       ? (Array.isArray(err.error.message) ? err.error.message.join(', ') : err.error.message)
-      : 'A apărut o eroare. Încearcă din nou.';
+      : this._transloco.translate('cars.toast.genericError');
     const toast = await this._toastCtrl.create({
       message,
       duration: 4000,
@@ -259,7 +261,7 @@ export class CarDetailsState {
     patchState({ submitting: false });
     dispatch(new CarListActions.RemoveCar(carId));
     const toast = await this._toastCtrl.create({
-      message: 'Mașina a fost ștearsă cu succes!',
+      message: this._transloco.translate('cars.toast.deleteSuccess'),
       duration: 2500,
       color: 'success',
       position: 'top',
@@ -273,7 +275,7 @@ export class CarDetailsState {
     patchState({ submitting: false });
     const message = err?.error?.message
       ? (Array.isArray(err.error.message) ? err.error.message.join(', ') : err.error.message)
-      : 'A apărut o eroare. Încearcă din nou.';
+      : this._transloco.translate('cars.toast.genericError');
     const toast = await this._toastCtrl.create({
       message,
       duration: 4000,
@@ -297,7 +299,7 @@ export class CarDetailsState {
     patchState({ submitting: false });
     dispatch(new CarListActions.UpdateCarInList(car));
     const toast = await this._toastCtrl.create({
-      message: 'Mașina a fost marcată ca vândută.',
+      message: this._transloco.translate('cars.toast.markSoldSuccess'),
       duration: 2500,
       color: 'success',
       position: 'top',
@@ -311,7 +313,7 @@ export class CarDetailsState {
     patchState({ submitting: false });
     const message = err?.error?.message
       ? (Array.isArray(err.error.message) ? err.error.message.join(', ') : err.error.message)
-      : 'A apărut o eroare. Încearcă din nou.';
+      : this._transloco.translate('cars.toast.genericError');
     const toast = await this._toastCtrl.create({
       message,
       duration: 4000,
@@ -335,7 +337,7 @@ export class CarDetailsState {
     patchState({ submitting: false });
     dispatch(new CarListActions.UpdateCarInList(car));
     const toast = await this._toastCtrl.create({
-      message: 'Mașina a fost restaurată în garaj.',
+      message: this._transloco.translate('cars.toast.restoreSuccess'),
       duration: 2500,
       color: 'success',
       position: 'top',
@@ -349,7 +351,7 @@ export class CarDetailsState {
     patchState({ submitting: false });
     const message = err?.error?.message
       ? (Array.isArray(err.error.message) ? err.error.message.join(', ') : err.error.message)
-      : 'A apărut o eroare. Încearcă din nou.';
+      : this._transloco.translate('cars.toast.genericError');
     const toast = await this._toastCtrl.create({
       message,
       duration: 4000,

--- a/src/app/features/cars/state/car-list/car-list.facade.ts
+++ b/src/app/features/cars/state/car-list/car-list.facade.ts
@@ -7,12 +7,12 @@ import { Observable } from 'rxjs';
 
 @Injectable()
 export class CarListFacade {
-  @Select(CarListState.carList) carList$!: Observable<CarDto[]>;
-  @Select(CarListState.activeCarList) activeCarList$!: Observable<CarDto[]>;
-  @Select(CarListState.soldCarList) soldCarList$!: Observable<CarDto[]>;
-  @Select(CarListState.loading) loading$!: Observable<boolean>;
-  @Select(CarListState.carDocumentsMap) carDocumentsMap$!: Observable<{ [carId: number]: DocumentDto[] | undefined }>;
-  @Select(CarListState.sharedCarList) sharedCarList$!: Observable<SharedCarEntry[]>;
+  carList$: Observable<CarDto[]> = this._store.select(CarListState.carList);
+  activeCarList$: Observable<CarDto[]> = this._store.select(CarListState.activeCarList);
+  soldCarList$: Observable<CarDto[]> = this._store.select(CarListState.soldCarList);
+  loading$: Observable<boolean> = this._store.select(CarListState.loading);
+  carDocumentsMap$: Observable<{ [carId: number]: DocumentDto[] | undefined }> = this._store.select(CarListState.carDocumentsMap);
+  sharedCarList$: Observable<SharedCarEntry[]> = this._store.select(CarListState.sharedCarList);
 
   constructor(private readonly _store: Store) { }
 

--- a/src/app/features/documents/document-detail/document-detail.component.html
+++ b/src/app/features/documents/document-detail/document-detail.component.html
@@ -10,7 +10,7 @@
     @if (vm) {
       <!-- ── Breadcrumb ──────────────────────────────────────────── -->
       <nav class="breadcrumb">
-        <button class="breadcrumb-link" (click)="goBack()">Documents</button>
+        <button class="breadcrumb-link" (click)="goBack()">{{ 'documents.title' | transloco }}</button>
         <ion-icon name="chevron-forward-outline" class="breadcrumb-sep"></ion-icon>
         <span class="breadcrumb-current">{{ vm.typeLabel }}</span>
       </nav>
@@ -29,11 +29,11 @@
         <div class="doc-header-actions">
           <button class="hdr-btn hdr-btn--edit" (click)="navigateToEdit()">
             <ion-icon name="create-outline"></ion-icon>
-            Edit
+            {{ 'common.edit' | transloco }}
           </button>
           <button class="hdr-btn hdr-btn--delete" (click)="deleteDocument()" [disabled]="deleting">
             <ion-icon name="trash-outline"></ion-icon>
-            Delete
+            {{ 'common.delete' | transloco }}
           </button>
         </div>
       </header>
@@ -43,16 +43,16 @@
 
         <!-- ── Document information ──────────────────────────── -->
         <section class="detail-card info-card">
-          <h2 class="card-title">Document information</h2>
+          <h2 class="card-title">{{ 'documents.detail.documentInfo' | transloco }}</h2>
           <dl class="info-grid">
 
             <div class="info-row">
               <div class="info-cell">
-                <dt class="info-label">Type</dt>
+                <dt class="info-label">{{ 'documents.columns.type' | transloco }}</dt>
                 <dd class="info-value">{{ vm.typeLabel }}</dd>
               </div>
               <div class="info-cell">
-                <dt class="info-label">Valid from</dt>
+                <dt class="info-label">{{ 'documents.detail.validFrom' | transloco }}</dt>
                 <dd class="info-value">
                   @if (vm.doc.issue_date) { {{ vm.doc.issue_date | date:'d MMM y' }} }
                   @else { <span class="info-dash">—</span> }
@@ -62,7 +62,7 @@
 
             <div class="info-row">
               <div class="info-cell">
-                <dt class="info-label">Vehicle</dt>
+                <dt class="info-label">{{ 'documents.columns.vehicle' | transloco }}</dt>
                 <dd class="info-value info-value--link" (click)="vm.car && navigateToEdit()">
                   {{ vm.carLabel }}
                   @if (vm.car) {
@@ -71,20 +71,20 @@
                 </dd>
               </div>
               <div class="info-cell">
-                <dt class="info-label">Valid until</dt>
+                <dt class="info-label">{{ 'documents.columns.validUntil' | transloco }}</dt>
                 <dd class="info-value info-value--expiry">
                   @if (vm.doc.expiry_date) {
                     {{ vm.doc.expiry_date | date:'d MMM y' }}
                     <span class="status-badge status-badge--{{ vm.status }}">
                       @switch (vm.status) {
-                        @case ('valid')     { Valid }
-                        @case ('expiring')  { Expiring }
-                        @case ('expired')   { Expired }
-                        @case ('no-expiry') { No expiry }
+                        @case ('valid')     { {{ 'documents.status.valid' | transloco }} }
+                        @case ('expiring')  { {{ 'documents.detail.expiring' | transloco }} }
+                        @case ('expired')   { {{ 'documents.status.expired' | transloco }} }
+                        @case ('no-expiry') { {{ 'documents.status.noExpiry' | transloco }} }
                       }
                     </span>
                   } @else {
-                    <span class="status-badge status-badge--no-expiry">No expiry</span>
+                    <span class="status-badge status-badge--no-expiry">{{ 'documents.status.noExpiry' | transloco }}</span>
                   }
                 </dd>
               </div>
@@ -93,12 +93,12 @@
             @if (vm.doc.provider) {
               <div class="info-row">
                 <div class="info-cell">
-                  <dt class="info-label">Provider</dt>
+                  <dt class="info-label">{{ 'documents.form.fields.provider' | transloco }}</dt>
                   <dd class="info-value">{{ vm.doc.provider }}</dd>
                 </div>
                 <div class="info-cell">
-                  <dt class="info-label">Status</dt>
-                  <dd class="info-value">{{ vm.doc.status ?? 'Active' }}</dd>
+                  <dt class="info-label">{{ 'documents.columns.status' | transloco }}</dt>
+                  <dd class="info-value">{{ vm.doc.status ?? ('documents.form.statusOptions.active' | transloco) }}</dd>
                 </div>
               </div>
             }
@@ -106,7 +106,7 @@
             @if (vm.doc.policy_number) {
               <div class="info-row">
                 <div class="info-cell info-cell--full">
-                  <dt class="info-label">Policy number</dt>
+                  <dt class="info-label">{{ 'documents.form.fields.policyNumber' | transloco }}</dt>
                   <dd class="info-value info-value--mono">{{ vm.doc.policy_number }}</dd>
                 </div>
               </div>
@@ -118,13 +118,13 @@
         <!-- ── Document file ──────────────────────────────────── -->
         @if (vm.doc.file_url) {
           <section class="detail-card file-card">
-            <h2 class="card-title">Document file</h2>
+            <h2 class="card-title">{{ 'documents.detail.documentFile' | transloco }}</h2>
 
             <div class="file-preview-wrap">
               @if (vm.isPdf) {
-                <iframe [src]="fileUrl" class="file-preview-iframe" title="Document preview"></iframe>
+                <iframe [src]="fileUrl" class="file-preview-iframe" [attr.title]="'documents.detail.documentPreview' | transloco"></iframe>
               } @else if (vm.isImage) {
-                <img [src]="rawFileUrl" class="file-preview-img" [alt]="vm.doc.file_name ?? 'Document'" />
+                <img [src]="rawFileUrl" class="file-preview-img" [alt]="vm.doc.file_name ?? ('documents.detail.document' | transloco)" />
               } @else {
                 <div class="file-preview-generic">
                   <ion-icon name="document-outline" class="file-generic-icon"></ion-icon>
@@ -144,7 +144,7 @@
 
             <a class="download-btn" [href]="rawFileUrl" [download]="vm.doc.file_name" target="_blank">
               <ion-icon name="cloud-download-outline"></ion-icon>
-              Download
+              {{ 'documents.detail.download' | transloco }}
             </a>
           </section>
         }
@@ -155,23 +155,23 @@
       @if (vm.doc.policyholder || vm.doc.cnp_id) {
         <section class="detail-card extracted-card">
           <h2 class="card-title">
-            Extracted information
+            {{ 'documents.detail.extractedInfo' | transloco }}
             <span class="card-title-note">
               <ion-icon name="information-circle-outline"></ion-icon>
-              Information extracted automatically from the document. You can edit if needed.
+              {{ 'documents.detail.extractedInfoNote' | transloco }}
             </span>
           </h2>
           <dl class="info-grid">
             <div class="info-row">
               @if (vm.doc.policyholder) {
                 <div class="info-cell">
-                  <dt class="info-label">Policyholder</dt>
+                  <dt class="info-label">{{ 'documents.form.fields.policyholder' | transloco }}</dt>
                   <dd class="info-value">{{ vm.doc.policyholder }}</dd>
                 </div>
               }
               @if (vm.doc.cnp_id) {
                 <div class="info-cell">
-                  <dt class="info-label">CNP / ID</dt>
+                  <dt class="info-label">{{ 'documents.form.fields.cnpId' | transloco }}</dt>
                   <dd class="info-value info-value--mono">{{ vm.doc.cnp_id }}</dd>
                 </div>
               }

--- a/src/app/features/documents/document-detail/document-detail.component.ts
+++ b/src/app/features/documents/document-detail/document-detail.component.ts
@@ -16,6 +16,7 @@ import {
 } from 'ionicons/icons';
 import { combineLatest } from 'rxjs';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { TranslocoPipe, TranslocoService } from '@ngneat/transloco';
 
 export interface DocumentDetailVm {
     doc: DocumentDto;
@@ -50,7 +51,7 @@ function formatBytes(bytes: number): string {
     selector: 'app-document-detail',
     templateUrl: 'document-detail.component.html',
     styleUrls: ['./document-detail.component.scss'],
-    imports: [IonContent, IonIcon, IonSpinner, DatePipe],
+    imports: [IonContent, IonIcon, IonSpinner, DatePipe, TranslocoPipe],
 })
 export class DocumentDetailComponent implements OnInit {
     vm: DocumentDetailVm | null = null;
@@ -63,6 +64,7 @@ export class DocumentDetailComponent implements OnInit {
         private readonly _router: Router,
         private readonly _nav: NavController,
         private readonly _sanitizer: DomSanitizer,
+        private readonly _transloco: TranslocoService,
     ) {
         addIcons({
             arrowBackOutline, createOutline, trashOutline,
@@ -93,7 +95,8 @@ export class DocumentDetailComponent implements OnInit {
 
     private buildVm(doc: DocumentDto, cars: CarDto[]): DocumentDetailVm {
         const car = cars.find(c => c.id === doc.car_id);
-        const cfg = DOC_TYPE_CONFIG[doc.document_type] ?? { label: doc.document_type, abbr: doc.document_type.slice(0, 3).toUpperCase(), color: 'slate' };
+        const cfg = DOC_TYPE_CONFIG[doc.document_type];
+        const fallbackAbbr = doc.document_type.slice(0, 3).toUpperCase();
         const { status, daysLeft } = calcStatus(doc.expiry_date);
         const ext = doc.file_name?.split('.').pop()?.toLowerCase() ?? '';
         return {
@@ -101,9 +104,9 @@ export class DocumentDetailComponent implements OnInit {
             car,
             status,
             daysLeft,
-            typeLabel: cfg.label,
-            typeAbbr: cfg.abbr,
-            typeColor: cfg.color,
+            typeLabel: cfg ? this._transloco.translate(cfg.label) : doc.document_type,
+            typeAbbr: cfg ? this._transloco.translate(cfg.abbr) : fallbackAbbr,
+            typeColor: cfg?.color ?? 'slate',
             carLabel: car ? `${car.make} ${car.model}` : '—',
             fileSizeLabel: doc.file_size ? formatBytes(doc.file_size) : null,
             isPdf: ext === 'pdf',

--- a/src/app/features/documents/documents-form/documents-form.component.html
+++ b/src/app/features/documents/documents-form/documents-form.component.html
@@ -9,7 +9,7 @@
       <div>
         <h1 class="form-title">{{ pageTitle }}</h1>
         <p class="form-subtitle">
-          {{ isEditMode ? 'Update the document details below.' : 'Fill in the document details below.' }}
+          {{ (isEditMode ? 'documents.form.editSubtitle' : 'documents.form.addSubtitle') | transloco }}
         </p>
       </div>
     </div>
@@ -20,18 +20,18 @@
 
         <!-- ── Section: Basic info ──────────────────────────────── -->
         <div class="form-section">
-          <h3 class="form-section-title">Basic information</h3>
+          <h3 class="form-section-title">{{ 'documents.form.basicInfo' | transloco }}</h3>
 
           <div class="two-col-row">
             <!-- Document Type -->
             <div class="field-group">
               <label class="field-label" for="doc-type">
-                Document type <span class="field-required">*</span>
+                {{ 'documents.form.fields.documentType' | transloco }} <span class="field-required">*</span>
               </label>
               <div class="select-wrap">
                 <select id="doc-type" class="field-select" formControlName="document_type"
                         [class.field-error]="isInvalid('document_type')">
-                  <option value="" disabled [selected]="!form.get('document_type')?.value">Select type</option>
+                  <option value="" disabled [selected]="!form.get('document_type')?.value">{{ 'documents.form.selectType' | transloco }}</option>
                   @for (t of docTypes; track t.value) {
                     <option [value]="t.value">{{ t.label }}</option>
                   }
@@ -39,19 +39,19 @@
                 <ion-icon name="chevron-down-outline" class="select-chevron"></ion-icon>
               </div>
               @if (isInvalid('document_type')) {
-                <span class="field-hint field-hint--error">Document type is required.</span>
+                <span class="field-hint field-hint--error">{{ 'documents.form.errors.documentTypeRequired' | transloco }}</span>
               }
             </div>
 
             <!-- Vehicle -->
             <div class="field-group">
               <label class="field-label" for="car-id">
-                Vehicle <span class="field-required">*</span>
+                {{ 'documents.columns.vehicle' | transloco }} <span class="field-required">*</span>
               </label>
               <div class="select-wrap">
                 <select id="car-id" class="field-select" formControlName="car_id"
                         [class.field-error]="isInvalid('car_id')">
-                  <option value="" disabled [selected]="!form.get('car_id')?.value">Select vehicle</option>
+                  <option value="" disabled [selected]="!form.get('car_id')?.value">{{ 'documents.form.selectVehicle' | transloco }}</option>
                   @for (car of cars; track car.id) {
                     <option [value]="car.id">{{ car.make }} {{ car.model }} · {{ car.license_plate }}</option>
                   }
@@ -59,7 +59,7 @@
                 <ion-icon name="chevron-down-outline" class="select-chevron"></ion-icon>
               </div>
               @if (isInvalid('car_id')) {
-                <span class="field-hint field-hint--error">Vehicle is required.</span>
+                <span class="field-hint field-hint--error">{{ 'documents.form.errors.vehicleRequired' | transloco }}</span>
               }
             </div>
           </div>
@@ -67,30 +67,30 @@
           <div class="two-col-row">
             <!-- Provider -->
             <div class="field-group">
-              <label class="field-label" for="provider">Provider</label>
+              <label class="field-label" for="provider">{{ 'documents.form.fields.provider' | transloco }}</label>
               <div class="input-wrap">
                 <input id="provider" type="text" class="field-input"
-                       formControlName="provider" placeholder="e.g. Allianz-Tiriac" />
+                       formControlName="provider" [placeholder]="'documents.form.placeholders.provider' | transloco" />
               </div>
             </div>
 
             <!-- Policy number -->
             <div class="field-group">
-              <label class="field-label" for="policy-number">Policy number</label>
+              <label class="field-label" for="policy-number">{{ 'documents.form.fields.policyNumber' | transloco }}</label>
               <div class="input-wrap">
                 <input id="policy-number" type="text" class="field-input"
-                       formControlName="policy_number" placeholder="e.g. POL-123456789" />
+                       formControlName="policy_number" [placeholder]="'documents.form.placeholders.policyNumber' | transloco" />
               </div>
             </div>
           </div>
 
           <!-- Status -->
           <div class="field-group field-group--half">
-            <label class="field-label" for="status">Status</label>
+            <label class="field-label" for="status">{{ 'documents.columns.status' | transloco }}</label>
             <div class="select-wrap">
               <select id="status" class="field-select" formControlName="status">
-                @for (s of statusOptions; track s) {
-                  <option [value]="s">{{ s }}</option>
+                @for (s of statusOptions; track s.value) {
+                  <option [value]="s.value">{{ s.label }}</option>
                 }
               </select>
               <ion-icon name="chevron-down-outline" class="select-chevron"></ion-icon>
@@ -100,11 +100,11 @@
 
         <!-- ── Section: Dates ───────────────────────────────────── -->
         <div class="form-section">
-          <h3 class="form-section-title">Validity</h3>
+          <h3 class="form-section-title">{{ 'documents.form.validity' | transloco }}</h3>
 
           <div class="dates-row">
             <div class="field-group">
-              <label class="field-label" for="issue-date">Issue date</label>
+              <label class="field-label" for="issue-date">{{ 'documents.form.fields.issueDate' | transloco }}</label>
               <div class="input-wrap">
                 <input id="issue-date" type="date" class="field-input" formControlName="issue_date" />
               </div>
@@ -112,9 +112,9 @@
 
             <div class="field-group">
               <label class="field-label" for="expiry-date">
-                Expiry date
+                {{ 'documents.form.fields.expiryDate' | transloco }}
                 @if (form.get('no_expiry')?.value) {
-                  <span class="no-expiry-label">— no expiry</span>
+                  <span class="no-expiry-label">{{ 'documents.form.noExpirySuffix' | transloco }}</span>
                 }
               </label>
               <div class="input-wrap">
@@ -126,13 +126,13 @@
 
           <label class="checkbox-row">
             <input type="checkbox" class="checkbox-input" formControlName="no_expiry" />
-            <span class="checkbox-label">This document has no expiry date</span>
+            <span class="checkbox-label">{{ 'documents.form.noExpiryCheckbox' | transloco }}</span>
           </label>
         </div>
 
         <!-- ── Section: Document file ───────────────────────────── -->
         <div class="form-section">
-          <h3 class="form-section-title">Document file</h3>
+          <h3 class="form-section-title">{{ 'documents.form.documentFile' | transloco }}</h3>
 
           @if (!selectedFile) {
             <!-- Drop zone -->
@@ -145,13 +145,13 @@
               (drop)="onDrop($event)">
               <ion-icon name="cloud-upload-outline" class="upload-zone-icon"></ion-icon>
               <p class="upload-zone-text">
-                <strong>Drag &amp; drop</strong> your document here
+                <strong>{{ 'documents.form.dragDrop' | transloco }}</strong> {{ 'documents.form.dragDropHere' | transloco }}
               </p>
-              <p class="upload-zone-hint">or click to browse · PDF, JPG, PNG up to 20 MB</p>
+              <p class="upload-zone-hint">{{ 'documents.form.uploadHint' | transloco }}</p>
               @if (existingFileName) {
                 <p class="upload-zone-existing">
                   <ion-icon name="attach-outline"></ion-icon>
-                  Current file: {{ existingFileName }}
+                  {{ 'documents.form.currentFile' | transloco:{ name: existingFileName } }}
                 </p>
               }
             </div>
@@ -177,7 +177,7 @@
           @if (extracting) {
             <div class="extraction-status">
               <ion-spinner name="crescent" class="extraction-spinner"></ion-spinner>
-              <span>Analysing your document…</span>
+              <span>{{ 'documents.form.analysingDocument' | transloco }}</span>
             </div>
           }
         </div>
@@ -204,22 +204,22 @@
 
         <!-- ── Section: Extracted info ──────────────────────────── -->
         <div class="form-section">
-          <h3 class="form-section-title">Additional details</h3>
+          <h3 class="form-section-title">{{ 'documents.form.additionalDetails' | transloco }}</h3>
 
           <div class="two-col-row">
             <div class="field-group">
-              <label class="field-label" for="policyholder">Policyholder</label>
+              <label class="field-label" for="policyholder">{{ 'documents.form.fields.policyholder' | transloco }}</label>
               <div class="input-wrap">
                 <input id="policyholder" type="text" class="field-input"
-                       formControlName="policyholder" placeholder="e.g. John Doe" />
+                       formControlName="policyholder" [placeholder]="'documents.form.placeholders.policyholder' | transloco" />
               </div>
             </div>
 
             <div class="field-group">
-              <label class="field-label" for="cnp-id">CNP / ID</label>
+              <label class="field-label" for="cnp-id">{{ 'documents.form.fields.cnpId' | transloco }}</label>
               <div class="input-wrap">
                 <input id="cnp-id" type="text" class="field-input"
-                       formControlName="cnp_id" placeholder="e.g. 1900101012345" />
+                       formControlName="cnp_id" [placeholder]="'documents.form.placeholders.cnpId' | transloco" />
               </div>
             </div>
           </div>
@@ -229,15 +229,15 @@
         <div class="form-actions">
           <button type="button" class="btn btn--ghost" (click)="cancel()" [disabled]="submitting || uploading">
             <ion-icon name="close-outline"></ion-icon>
-            Cancel
+            {{ 'common.cancel' | transloco }}
           </button>
           <button type="submit" class="btn btn--primary" [disabled]="submitting || uploading">
             @if (submitting || uploading) {
               <ion-spinner name="crescent" class="btn-spinner"></ion-spinner>
-              {{ uploading ? 'Uploading…' : 'Saving…' }}
+              {{ (uploading ? 'documents.form.uploading' : 'common.saving') | transloco }}
             } @else {
               <ion-icon name="save-outline"></ion-icon>
-              {{ isEditMode ? 'Save changes' : 'Add document' }}
+              {{ (isEditMode ? 'documents.form.saveChanges' : 'documents.addDocument') | transloco }}
             }
           </button>
         </div>

--- a/src/app/features/documents/documents-form/documents-form.component.ts
+++ b/src/app/features/documents/documents-form/documents-form.component.ts
@@ -17,13 +17,14 @@ import {
 } from 'ionicons/icons';
 import { combineLatest, take } from 'rxjs';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { TranslocoPipe, TranslocoService } from '@ngneat/transloco';
 
 @UntilDestroy()
 @Component({
     selector: 'app-documents-form',
     templateUrl: 'documents-form.component.html',
     styleUrls: ['./documents-form.component.scss'],
-    imports: [IonContent, IonIcon, IonSpinner, ReactiveFormsModule],
+    imports: [IonContent, IonIcon, IonSpinner, ReactiveFormsModule, TranslocoPipe],
 })
 export class DocumentsFormComponent implements OnInit {
     form!: FormGroup;
@@ -40,14 +41,13 @@ export class DocumentsFormComponent implements OnInit {
     extractionResult: ExtractionResultDto | null = null;
     extractionFailed = false;
 
-    readonly docTypes = Object.entries(DOC_TYPE_CONFIG).map(([value, cfg]) => ({
-        value, label: cfg.label, color: cfg.color,
-    }));
-
-    readonly statusOptions = ['Active', 'Inactive', 'Expired'];
+    readonly docTypes: { value: string; label: string; color: string }[];
+    readonly statusOptions: { value: string; label: string }[];
 
     get isEditMode(): boolean { return !!this.editDoc; }
-    get pageTitle(): string { return this.isEditMode ? 'Edit Document' : 'Add Document'; }
+    get pageTitle(): string {
+        return this._transloco.translate(this.isEditMode ? 'documents.form.editTitle' : 'documents.form.addTitle');
+    }
 
     constructor(
         private readonly _fb: FormBuilder,
@@ -56,6 +56,7 @@ export class DocumentsFormComponent implements OnInit {
         private readonly _route: ActivatedRoute,
         private readonly _docService: DocumentService,
         private readonly _upload: UploadService,
+        private readonly _transloco: TranslocoService,
     ) {
         addIcons({
             addOutline, calendarOutline, carOutline,
@@ -64,6 +65,16 @@ export class DocumentsFormComponent implements OnInit {
             cloudUploadOutline, trashOutline, attachOutline,
             informationCircleOutline, warningOutline,
         });
+
+        this.docTypes = Object.entries(DOC_TYPE_CONFIG).map(([value, cfg]) => ({
+            value, label: this._transloco.translate(cfg.label), color: cfg.color,
+        }));
+
+        this.statusOptions = [
+            { value: 'Active',   label: this._transloco.translate('documents.form.statusOptions.active') },
+            { value: 'Inactive', label: this._transloco.translate('documents.form.statusOptions.inactive') },
+            { value: 'Expired',  label: this._transloco.translate('documents.form.statusOptions.expired') },
+        ];
 
         this.form = this._fb.group({
             document_type: [null, Validators.required],
@@ -258,20 +269,20 @@ export class DocumentsFormComponent implements OnInit {
     }
 
     get extractionBannerTitle(): string {
-        if (this.extractionFailed) return 'Could not read the document';
+        if (this.extractionFailed) return this._transloco.translate('documents.form.extraction.failedTitle');
         if (!this.extractionResult) return '';
-        if (!this.extractionResult.detected) return 'Document type not recognised';
-        return this.extractionResult.confidence === 'high'
-            ? 'Fields pre-filled from your document'
-            : 'Fields extracted with lower confidence';
+        if (!this.extractionResult.detected) return this._transloco.translate('documents.form.extraction.notRecognisedTitle');
+        return this._transloco.translate(this.extractionResult.confidence === 'high'
+            ? 'documents.form.extraction.highConfidenceTitle'
+            : 'documents.form.extraction.lowConfidenceTitle');
     }
 
     get extractionBannerDesc(): string {
-        if (this.extractionFailed) return 'The document could not be analysed. Please fill in the fields manually.';
+        if (this.extractionFailed) return this._transloco.translate('documents.form.extraction.failedDesc');
         if (!this.extractionResult) return '';
-        if (!this.extractionResult.detected) return 'We could not identify this document type. Please fill in the fields manually.';
-        return this.extractionResult.confidence === 'high'
-            ? 'Please review the pre-filled values and correct any errors before saving.'
-            : 'Some values may be inaccurate — please verify all fields carefully before saving.';
+        if (!this.extractionResult.detected) return this._transloco.translate('documents.form.extraction.notRecognisedDesc');
+        return this._transloco.translate(this.extractionResult.confidence === 'high'
+            ? 'documents.form.extraction.highConfidenceDesc'
+            : 'documents.form.extraction.lowConfidenceDesc');
     }
 }

--- a/src/app/features/documents/documents-list/documents-list.component.html
+++ b/src/app/features/documents/documents-list/documents-list.component.html
@@ -4,13 +4,13 @@
     <!-- ── Page header ──────────────────────────────────────────── -->
     <header class="docs-header">
       <div class="docs-header-left">
-        <h1 class="docs-title">Documents</h1>
-        <p class="docs-subtitle">All documents for your vehicles</p>
+        <h1 class="docs-title">{{ 'documents.title' | transloco }}</h1>
+        <p class="docs-subtitle">{{ 'documents.subtitle' | transloco }}</p>
       </div>
       <div class="docs-header-right">
         <button class="add-doc-btn" (click)="navigateToAdd()">
           <ion-icon name="add-outline"></ion-icon>
-          Add document
+          {{ 'documents.addDocument' | transloco }}
         </button>
       </div>
     </header>
@@ -20,7 +20,7 @@
 
       <div class="filter-select-wrap">
         <select class="filter-select" (change)="onCarChange($event)">
-          <option value="all">All vehicles</option>
+          <option value="all">{{ 'documents.filters.allVehicles' | transloco }}</option>
           @for (car of availableCars; track car.id) {
             <option [value]="car.id">{{ car.make }} {{ car.model }}</option>
           }
@@ -30,7 +30,7 @@
 
       <div class="filter-select-wrap">
         <select class="filter-select" (change)="onTypeChange($event)">
-          <option value="all">All document types</option>
+          <option value="all">{{ 'documents.filters.allTypes' | transloco }}</option>
           @for (type of availableTypes; track type) {
             <option [value]="type">{{ docTypeLabelFor(type) }}</option>
           }
@@ -41,7 +41,7 @@
       <div class="filter-select-wrap">
         <select class="filter-select" (change)="onStatusChange($event)">
           @for (s of statuses; track s.value) {
-            <option [value]="s.value">{{ s.label }}</option>
+            <option [value]="s.value">{{ s.label | transloco }}</option>
           }
         </select>
         <ion-icon name="chevron-down-outline" class="select-chevron"></ion-icon>
@@ -52,7 +52,7 @@
         <input
           class="search-input"
           type="text"
-          placeholder="Search documents..."
+          [placeholder]="'documents.filters.search' | transloco"
           [value]="searchQuery"
           (input)="onSearchInput($event)" />
       </div>
@@ -63,7 +63,7 @@
     @if (loading) {
       <div class="loading-state">
         <ion-spinner name="crescent"></ion-spinner>
-        <p>Loading documents…</p>
+        <p>{{ 'documents.loading' | transloco }}</p>
       </div>
     }
 
@@ -73,15 +73,15 @@
         <ion-icon name="document-text-outline" class="empty-icon"></ion-icon>
         <p class="empty-text">
           @if (totalAll === 0) {
-            No documents yet. Add your first document.
+            {{ 'documents.empty.noDocuments' | transloco }}
           } @else {
-            No documents match your filters.
+            {{ 'documents.empty.noResults' | transloco }}
           }
         </p>
         @if (totalAll === 0) {
           <button class="empty-cta" (click)="navigateToAdd()">
             <ion-icon name="add-outline"></ion-icon>
-            Add document
+            {{ 'documents.addDocument' | transloco }}
           </button>
         }
       </div>
@@ -95,12 +95,12 @@
         <table class="doc-table">
           <thead>
             <tr>
-              <th class="col-doc">Document</th>
-              <th class="col-vehicle">Vehicle</th>
-              <th class="col-type">Type</th>
-              <th class="col-date">Valid until</th>
-              <th class="col-status">Status</th>
-              <th class="col-actions">Actions</th>
+              <th class="col-doc">{{ 'documents.columns.document' | transloco }}</th>
+              <th class="col-vehicle">{{ 'documents.columns.vehicle' | transloco }}</th>
+              <th class="col-type">{{ 'documents.columns.type' | transloco }}</th>
+              <th class="col-date">{{ 'documents.columns.validUntil' | transloco }}</th>
+              <th class="col-status">{{ 'documents.columns.status' | transloco }}</th>
+              <th class="col-actions">{{ 'documents.columns.actions' | transloco }}</th>
             </tr>
           </thead>
           <tbody>
@@ -133,29 +133,29 @@
                 <td class="col-status">
                   <span class="status-badge status-badge--{{ item.status }}">
                     @switch (item.status) {
-                      @case ('valid')     { Valid }
-                      @case ('expiring')  { Expiring soon }
-                      @case ('expired')   { Expired }
-                      @case ('no-expiry') { No expiry }
+                      @case ('valid')     { {{ 'documents.status.valid' | transloco }} }
+                      @case ('expiring')  { {{ 'documents.status.expiring' | transloco }} }
+                      @case ('expired')   { {{ 'documents.status.expired' | transloco }} }
+                      @case ('no-expiry') { {{ 'documents.status.noExpiry' | transloco }} }
                     }
                   </span>
                 </td>
                 <td class="col-actions" (click)="$event.stopPropagation()">
                   <div class="actions-wrap">
-                    <button class="action-btn" title="View" (click)="navigateToView(item.doc.id)">
+                    <button class="action-btn" [attr.title]="'common.view' | transloco" (click)="navigateToView(item.doc.id)">
                       <ion-icon name="eye-outline"></ion-icon>
                     </button>
                     <div class="action-more-wrap" (click)="$event.stopPropagation()">
-                      <button class="action-btn" title="More" (click)="toggleMenu($event, item.doc.id)">
+                      <button class="action-btn" [attr.title]="'common.more' | transloco" (click)="toggleMenu($event, item.doc.id)">
                         <ion-icon name="ellipsis-horizontal-outline"></ion-icon>
                       </button>
                       @if (openMenuId === item.doc.id) {
                         <div class="action-menu">
                           <button class="action-menu-item" (click)="navigateToEdit($event, item.doc.id)">
-                            <ion-icon name="create-outline"></ion-icon> Edit
+                            <ion-icon name="create-outline"></ion-icon> {{ 'common.edit' | transloco }}
                           </button>
                           <button class="action-menu-item danger" (click)="deleteDocument($event, item.doc.id)">
-                            <ion-icon name="trash-outline"></ion-icon> Delete
+                            <ion-icon name="trash-outline"></ion-icon> {{ 'common.delete' | transloco }}
                           </button>
                         </div>
                       }
@@ -168,7 +168,7 @@
         </table>
 
         <div class="table-footer">
-          Showing 1 to {{ totalCount }} of {{ totalAll }} documents
+          {{ 'documents.footer.showing' | transloco:{ from: totalCount > 0 ? 1 : 0, to: totalCount, total: totalAll } }}
         </div>
       </div>
     }
@@ -190,10 +190,10 @@
                 <span class="card-name">{{ item.typeLabel }}</span>
                 <span class="status-badge status-badge--{{ item.status }}">
                   @switch (item.status) {
-                    @case ('valid')     { Valid }
-                    @case ('expiring')  { Expiring soon }
-                    @case ('expired')   { Expired }
-                    @case ('no-expiry') { No expiry }
+                    @case ('valid')     { {{ 'documents.status.valid' | transloco }} }
+                    @case ('expiring')  { {{ 'documents.status.expiring' | transloco }} }
+                    @case ('expired')   { {{ 'documents.status.expired' | transloco }} }
+                    @case ('no-expiry') { {{ 'documents.status.noExpiry' | transloco }} }
                   }
                 </span>
               </div>
@@ -209,12 +209,12 @@
                     <span class="days-badge">{{ item.daysLeft }}d left</span>
                   }
                 } @else {
-                  <span class="no-expiry-dash">No expiry</span>
+                  <span class="no-expiry-dash">{{ 'documents.status.noExpiry' | transloco }}</span>
                 }
               </div>
             </div>
             <div class="card-actions" (click)="$event.stopPropagation()">
-              <button class="action-btn" title="View" (click)="navigateToView(item.doc.id)">
+              <button class="action-btn" [attr.title]="'common.view' | transloco" (click)="navigateToView(item.doc.id)">
                 <ion-icon name="eye-outline"></ion-icon>
               </button>
               <div class="action-more-wrap">
@@ -224,10 +224,10 @@
                 @if (openMenuId === item.doc.id) {
                   <div class="action-menu action-menu--left">
                     <button class="action-menu-item" (click)="navigateToEdit($event, item.doc.id)">
-                      <ion-icon name="create-outline"></ion-icon> Edit
+                      <ion-icon name="create-outline"></ion-icon> {{ 'common.edit' | transloco }}
                     </button>
                     <button class="action-menu-item danger" (click)="deleteDocument($event, item.doc.id)">
-                      <ion-icon name="trash-outline"></ion-icon> Delete
+                      <ion-icon name="trash-outline"></ion-icon> {{ 'common.delete' | transloco }}
                     </button>
                   </div>
                 }
@@ -237,7 +237,7 @@
         }
 
         <div class="list-end-note">
-          Showing {{ totalCount }} of {{ totalAll }} documents
+          {{ 'documents.footer.showingShort' | transloco:{ count: totalCount, total: totalAll } }}
         </div>
       </div>
     }

--- a/src/app/features/documents/documents-list/documents-list.component.ts
+++ b/src/app/features/documents/documents-list/documents-list.component.ts
@@ -15,6 +15,7 @@ import {
 } from 'ionicons/icons';
 import { combineLatest } from 'rxjs';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { TranslocoPipe, TranslocoService } from '@ngneat/transloco';
 
 export type DocStatus = 'valid' | 'expiring' | 'expired' | 'no-expiry';
 
@@ -32,11 +33,11 @@ export interface DocViewModel {
 const EXPIRY_SOON_DAYS = 30;
 
 export const DOC_TYPE_CONFIG: Record<string, { label: string; abbr: string; color: string }> = {
-    RCA:          { label: 'Insurance (RCA)',          abbr: 'RCA', color: 'purple' },
-    ITP:          { label: 'ITP Certificate',           abbr: 'ITP', color: 'blue' },
-    ROV:          { label: 'ROV Certificate',           abbr: 'ROV', color: 'indigo' },
-    REGISTRATION: { label: 'Registration Certificate',  abbr: 'CAR', color: 'green' },
-    ROAD_TAX:     { label: 'Road Tax',                  abbr: 'TAX', color: 'amber' },
+    RCA:          { label: 'documents.types.RCA',          abbr: 'documents.typeAbbr.RCA',          color: 'purple' },
+    ITP:          { label: 'documents.types.ITP',          abbr: 'documents.typeAbbr.ITP',          color: 'blue' },
+    ROV:          { label: 'documents.types.ROV',          abbr: 'documents.typeAbbr.ROV',          color: 'indigo' },
+    REGISTRATION: { label: 'documents.types.REGISTRATION', abbr: 'documents.typeAbbr.REGISTRATION', color: 'green' },
+    ROAD_TAX:     { label: 'documents.types.ROAD_TAX',     abbr: 'documents.typeAbbr.ROAD_TAX',     color: 'amber' },
 };
 
 function docTypeConfig(type: string) {
@@ -51,7 +52,7 @@ function calcStatus(expiryDate: string | null | undefined): { status: DocStatus;
     return { status: 'valid', daysLeft };
 }
 
-function buildViewModel(doc: DocumentDto, cars: CarDto[]): DocViewModel {
+function buildViewModel(doc: DocumentDto, cars: CarDto[], transloco: TranslocoService): DocViewModel {
     const car  = cars.find(c => c.id === doc.car_id);
     const cfg  = docTypeConfig(doc.document_type);
     const { status, daysLeft } = calcStatus(doc.expiry_date);
@@ -60,8 +61,8 @@ function buildViewModel(doc: DocumentDto, cars: CarDto[]): DocViewModel {
         car,
         status,
         daysLeft,
-        typeLabel:  cfg.label,
-        typeAbbr:   cfg.abbr,
+        typeLabel:  transloco.translate(cfg.label),
+        typeAbbr:   transloco.translate(cfg.abbr),
         typeColor:  cfg.color,
         carLabel:   car ? `${car.make} ${car.model}` : '—',
     };
@@ -72,7 +73,7 @@ function buildViewModel(doc: DocumentDto, cars: CarDto[]): DocViewModel {
     selector: 'app-documents-list',
     templateUrl: 'documents-list.component.html',
     styleUrls: ['./documents-list.component.scss'],
-    imports: [IonContent, IonIcon, IonSpinner, DatePipe],
+    imports: [IonContent, IonIcon, IonSpinner, DatePipe, TranslocoPipe],
 })
 export class DocumentsListComponent implements OnInit {
     loading = false;
@@ -97,16 +98,17 @@ export class DocumentsListComponent implements OnInit {
     }
 
     readonly statuses: { value: DocStatus | 'all'; label: string }[] = [
-        { value: 'all',       label: 'All statuses' },
-        { value: 'valid',     label: 'Valid' },
-        { value: 'expiring',  label: 'Expiring soon' },
-        { value: 'expired',   label: 'Expired' },
-        { value: 'no-expiry', label: 'No expiry' },
+        { value: 'all',       label: 'documents.filters.allStatuses' },
+        { value: 'valid',     label: 'documents.status.valid' },
+        { value: 'expiring',  label: 'documents.status.expiring' },
+        { value: 'expired',   label: 'documents.status.expired' },
+        { value: 'no-expiry', label: 'documents.status.noExpiry' },
     ];
 
     constructor(
         private readonly _facade: DocumentsFacade,
         private readonly _router: Router,
+        private readonly _transloco: TranslocoService,
     ) {
         addIcons({
             addOutline, chevronDownOutline, searchOutline,
@@ -123,7 +125,7 @@ export class DocumentsListComponent implements OnInit {
             .subscribe(([cars, documents, loading]) => {
                 this.loading = loading;
                 this.cars = cars;
-                this.allDocs = documents.map(doc => buildViewModel(doc, cars));
+                this.allDocs = documents.map(doc => buildViewModel(doc, cars, this._transloco));
                 this.applyFilters();
             });
 
@@ -214,5 +216,5 @@ export class DocumentsListComponent implements OnInit {
     get totalAll(): number   { return this.allDocs.length; }
 
     readonly docTypeConfig = DOC_TYPE_CONFIG;
-    docTypeLabelFor(type: string): string { return docTypeConfig(type).label; }
+    docTypeLabelFor(type: string): string { return this._transloco.translate(docTypeConfig(type).label); }
 }

--- a/src/app/features/main/main.component.html
+++ b/src/app/features/main/main.component.html
@@ -123,10 +123,22 @@
         <!-- ── FOOTER: Settings + Logout + Version ──────────────── -->
         <div class="sidebar-footer">
 
+          <div class="lang-switcher" role="group" [attr.aria-label]="'sidebar.language' | transloco">
+            @for (lang of languages; track lang.code) {
+              <button
+                type="button"
+                class="lang-switcher__btn"
+                [class.active]="activeLang === lang.code"
+                (click)="setLanguage(lang.code)">
+                {{ lang.label }}
+              </button>
+            }
+          </div>
+
           <ion-item detail="false" class="footer-item disabled">
             <ion-icon slot="start" [src]="icons.settings"></ion-icon>
             <ion-label>{{ 'sidebar.settings' | transloco }}</ion-label>
-            <span slot="end" class="wip-badge">Soon</span>
+            <span slot="end" class="wip-badge">{{ 'common.soon' | transloco }}</span>
           </ion-item>
 
           <ion-item button detail="false" class="footer-item logout" (click)="logout()">
@@ -140,12 +152,12 @@
             @switch (versionService.status()) {
               @case ('up-to-date') {
                 <span class="version-sep">•</span>
-                <span>You're up to date</span>
+                <span>{{ 'sidebar.version.upToDate' | transloco }}</span>
                 <ion-icon [src]="icons.checkCircle" class="version-check"></ion-icon>
               }
               @case ('outdated') {
                 <span class="version-sep">•</span>
-                <span class="version-update">Update available</span>
+                <span class="version-update">{{ 'sidebar.version.updateAvailable' | transloco }}</span>
               }
               @default {}
             }

--- a/src/app/features/main/main.component.scss
+++ b/src/app/features/main/main.component.scss
@@ -582,6 +582,41 @@ ion-split-pane {
   }
 }
 
+// ── Language switcher ─────────────────────────────────────────────────────────
+.lang-switcher {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin: 2px 0 8px;
+  padding: 3px;
+  background: var(--sb-surface);
+  border: 1px solid var(--sb-border);
+  border-radius: var(--sb-r-pill);
+}
+
+.lang-switcher__btn {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: var(--sb-text-muted);
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  padding: 6px 0;
+  border-radius: var(--sb-r-pill);
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease;
+
+  &:hover {
+    color: var(--sb-text);
+  }
+
+  &.active {
+    background: var(--sb-accent-lighter);
+    color: var(--sb-accent);
+  }
+}
+
 // ── WIP badge ─────────────────────────────────────────────────────────────────
 .wip-badge {
   display: inline-flex;

--- a/src/app/features/main/main.component.ts
+++ b/src/app/features/main/main.component.ts
@@ -9,12 +9,13 @@ import {
 import { addIcons } from 'ionicons';
 import { mailOutline, carOutline } from 'ionicons/icons';
 import { filter, forkJoin } from 'rxjs';
-import { TranslocoPipe } from '@ngneat/transloco';
+import { TranslocoPipe, TranslocoService } from '@ngneat/transloco';
 import { AuthService } from '@hau/features/auth/auth.service';
 import { CARS_ROUTES } from '@hau/features/cars/cars.routes.const';
 import { HAU_ROUTES } from '@hau/app.routes.const';
 import { ThemeService } from '@hau/core/theme.service';
 import { VersionService } from '@hau/core/version.service';
+import { LANGUAGE_STORAGE_KEY } from '@hau/core/transloco/transloco-http-loader.service';
 import { CarAccessService } from '@hau/autogenapi/services/car-access.service';
 import { CarService } from '@hau/autogenapi/services/car.service';
 import { CarDto, SharedCarDto } from '@hau/autogenapi/models';
@@ -41,6 +42,12 @@ export interface AttentionItem {
 })
 export class MainComponent implements OnInit {
   readonly versionService = inject(VersionService);
+  readonly transloco = inject(TranslocoService);
+
+  readonly languages: { code: string; label: string }[] = [
+    { code: 'en', label: 'EN' },
+    { code: 'ro', label: 'RO' },
+  ];
   vehicleCount = 0;
   sharedVehicleCount = 0;
   currentPath = this.router.url;
@@ -171,6 +178,16 @@ export class MainComponent implements OnInit {
   goBack(): void { this.location.back(); }
 
   toggleTheme(): void { this.themeService.toggle(); }
+
+  get activeLang(): string {
+    return this.transloco.getActiveLang();
+  }
+
+  setLanguage(lang: string): void {
+    if (lang === this.activeLang) return;
+    this.transloco.setActiveLang(lang);
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, lang);
+  }
 
   private closeMenu(): Promise<boolean> {
     return this.menuCtrl.close();

--- a/src/app/features/maintenance/add-maintenance-panel/add-maintenance-panel.component.html
+++ b/src/app/features/maintenance/add-maintenance-panel/add-maintenance-panel.component.html
@@ -3,8 +3,8 @@
 <div class="amp-panel">
   <div class="amp-header">
     <div class="amp-header-text">
-      <h2 class="amp-title">Adaugă întreținere</h2>
-      <p class="amp-subtitle">Înregistrează un service sau o reparație</p>
+      <h2 class="amp-title">{{ 'maintenance.form.title' | transloco }}</h2>
+      <p class="amp-subtitle">{{ 'maintenance.form.subtitle' | transloco }}</p>
     </div>
     <button class="amp-close" (click)="close()">
       <ion-icon name="close-outline"></ion-icon>
@@ -15,7 +15,7 @@
 
     @if (cars.length > 1) {
       <div class="amp-field">
-        <label class="amp-label">Mașină</label>
+        <label class="amp-label">{{ 'maintenance.form.fields.vehicle' | transloco }}</label>
         <select class="amp-select" formControlName="car_id">
           @for (car of cars; track car.id) {
             <option [value]="car.id">{{ car.make }} {{ car.model }} @if (car.year) { · {{ car.year }} }</option>
@@ -26,59 +26,59 @@
 
     <div class="amp-row">
       <div class="amp-field">
-        <label class="amp-label">Dată service <span class="req">*</span></label>
+        <label class="amp-label">{{ 'maintenance.form.fields.serviceDate' | transloco }} <span class="req">*</span></label>
         <input class="amp-input" type="date" formControlName="service_date" />
       </div>
       <div class="amp-field">
-        <label class="amp-label">Kilometraj <span class="req">*</span></label>
-        <input class="amp-input" type="number" placeholder="ex: 51000" formControlName="mileage" min="0" />
+        <label class="amp-label">{{ 'maintenance.form.fields.mileage' | transloco }} <span class="req">*</span></label>
+        <input class="amp-input" type="number" [placeholder]="'maintenance.form.placeholders.mileage' | transloco" formControlName="mileage" min="0" />
       </div>
     </div>
 
     <div class="amp-row">
       <div class="amp-field">
-        <label class="amp-label">Categorie <span class="req">*</span></label>
+        <label class="amp-label">{{ 'maintenance.form.fields.category' | transloco }} <span class="req">*</span></label>
         <select class="amp-select" formControlName="service_category">
           @for (cat of categories; track cat.value) {
-            <option [value]="cat.value">{{ cat.label }}</option>
+            <option [value]="cat.value">{{ cat.label | transloco }}</option>
           }
         </select>
       </div>
       <div class="amp-field">
-        <label class="amp-label">Tip <span class="req">*</span></label>
+        <label class="amp-label">{{ 'maintenance.form.fields.type' | transloco }} <span class="req">*</span></label>
         <select class="amp-select" formControlName="service_type">
           @for (t of serviceTypes; track t.value) {
-            <option [value]="t.value">{{ t.label }}</option>
+            <option [value]="t.value">{{ t.label | transloco }}</option>
           }
         </select>
       </div>
     </div>
 
     <div class="amp-field">
-      <label class="amp-label">Descriere / Piese <span class="req">*</span></label>
-      <textarea class="amp-textarea" formControlName="description" placeholder="ex: Ulei 10W40, filtru aer MANN, filtru ulei" rows="3"></textarea>
+      <label class="amp-label">{{ 'maintenance.form.fields.description' | transloco }} <span class="req">*</span></label>
+      <textarea class="amp-textarea" formControlName="description" [placeholder]="'maintenance.form.placeholders.description' | transloco" rows="3"></textarea>
     </div>
 
     <div class="amp-row">
       <div class="amp-field">
-        <label class="amp-label">Cost (RON) <span class="req">*</span></label>
-        <input class="amp-input" type="number" placeholder="ex: 250" formControlName="cost" min="0" />
+        <label class="amp-label">{{ 'maintenance.form.fields.cost' | transloco }} <span class="req">*</span></label>
+        <input class="amp-input" type="number" [placeholder]="'maintenance.form.placeholders.cost' | transloco" formControlName="cost" min="0" />
       </div>
       <div class="amp-field">
-        <label class="amp-label">Data expirare / reminder</label>
+        <label class="amp-label">{{ 'maintenance.form.fields.expiryDate' | transloco }}</label>
         <input class="amp-input" type="date" formControlName="expiry_date" />
       </div>
     </div>
 
     <div class="amp-footer">
-      <button type="button" class="amp-btn-cancel" (click)="close()">Anulează</button>
+      <button type="button" class="amp-btn-cancel" (click)="close()">{{ 'common.cancel' | transloco }}</button>
       <button type="submit" class="amp-btn-save" [disabled]="form.invalid || submitting">
         @if (submitting) {
           <ion-spinner name="crescent" class="amp-spinner"></ion-spinner>
-          Se salvează…
+          {{ 'common.saving' | transloco }}
         } @else {
           <ion-icon name="save-outline"></ion-icon>
-          Salvează
+          {{ 'common.save' | transloco }}
         }
       </button>
     </div>

--- a/src/app/features/maintenance/add-maintenance-panel/add-maintenance-panel.component.ts
+++ b/src/app/features/maintenance/add-maintenance-panel/add-maintenance-panel.component.ts
@@ -7,13 +7,14 @@ import { IonIcon, IonSpinner } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
 import { closeOutline, saveOutline, addOutline } from 'ionicons/icons';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { TranslocoPipe } from '@ngneat/transloco';
 
 @UntilDestroy()
 @Component({
   selector: 'app-add-maintenance-panel',
   templateUrl: 'add-maintenance-panel.component.html',
   styleUrls: ['./add-maintenance-panel.component.scss'],
-  imports: [ReactiveFormsModule, IonIcon, IonSpinner],
+  imports: [ReactiveFormsModule, IonIcon, IonSpinner, TranslocoPipe],
 })
 export class AddMaintenancePanelComponent implements OnInit {
   @Input() selectedCarId: number | null = null;
@@ -27,9 +28,9 @@ export class AddMaintenancePanelComponent implements OnInit {
 
   readonly categories = CATEGORY_CONFIG;
   readonly serviceTypes = [
-    { value: 'MAINTENANCE', label: 'Întreținere' },
-    { value: 'REPAIR',      label: 'Reparație' },
-    { value: 'IMPROVEMENT', label: 'Îmbunătățire' },
+    { value: 'MAINTENANCE', label: 'maintenance.form.serviceTypes.maintenance' },
+    { value: 'REPAIR',      label: 'maintenance.form.serviceTypes.repair' },
+    { value: 'IMPROVEMENT', label: 'maintenance.form.serviceTypes.improvement' },
   ];
 
   constructor(

--- a/src/app/features/maintenance/maintenance.component.html
+++ b/src/app/features/maintenance/maintenance.component.html
@@ -19,8 +19,8 @@
       <!-- HEADER -->
       <div class="mn-header">
         <div class="mn-header-text">
-          <h1 class="mn-title">Întreținere</h1>
-          <p class="mn-subtitle">Urmărește istoricul service-ului, sarcinile viitoare și îngrijirea vehiculului.</p>
+          <h1 class="mn-title">{{ 'maintenance.title' | transloco }}</h1>
+          <p class="mn-subtitle">{{ 'maintenance.subtitle' | transloco }}</p>
         </div>
 
         <div class="mn-header-actions">
@@ -50,7 +50,7 @@
 
           <button class="btn-primary" (click)="addPanelOpen = true">
             <ion-icon name="add-outline"></ion-icon>
-            Adaugă întreținere
+            {{ 'cars.details.addMaintenance' | transloco }}
           </button>
         </div>
       </div>
@@ -65,11 +65,11 @@
                 <ion-icon name="water-outline"></ion-icon>
               </div>
               <div class="stat-card__body">
-                <span class="stat-card__label">Ultimul schimb ulei</span>
+                <span class="stat-card__label">{{ 'maintenance.stats.lastOilChange' | transloco }}</span>
                 @if (stats.lastOilDate) {
                   <span class="stat-card__value">{{ formatDate(stats.lastOilDate) }}</span>
                   @if (stats.lastOilMileage) {
-                    <span class="stat-card__sub">la {{ formatMileage(stats.lastOilMileage) }}</span>
+                    <span class="stat-card__sub">{{ 'maintenance.stats.at' | transloco:{ value: formatMileage(stats.lastOilMileage) } }}</span>
                   }
                 } @else {
                   <span class="stat-card__value stat-card__value--empty">—</span>
@@ -82,7 +82,7 @@
                 <ion-icon name="speedometer-outline"></ion-icon>
               </div>
               <div class="stat-card__body">
-                <span class="stat-card__label">Kilometraj curent</span>
+                <span class="stat-card__label">{{ 'car.fields.initialMileage' | transloco }}</span>
                 <span class="stat-card__value">{{ formatMileage(car.current_mileage) }}</span>
               </div>
             </div>
@@ -92,9 +92,9 @@
                 <ion-icon name="list-outline"></ion-icon>
               </div>
               <div class="stat-card__body">
-                <span class="stat-card__label">Total înregistrări</span>
+                <span class="stat-card__label">{{ 'maintenance.stats.totalRecords' | transloco }}</span>
                 <span class="stat-card__value">{{ stats.totalRecords }}</span>
-                <span class="stat-card__sub">intrări de întreținere</span>
+                <span class="stat-card__sub">{{ 'maintenance.stats.entries' | transloco }}</span>
               </div>
             </div>
 
@@ -103,10 +103,10 @@
                 <ion-icon name="time-outline"></ion-icon>
               </div>
               <div class="stat-card__body">
-                <span class="stat-card__label">Următor service</span>
+                <span class="stat-card__label">{{ 'maintenance.stats.nextService' | transloco }}</span>
                 @if (stats.nextServiceDate) {
-                  <span class="stat-card__value">În {{ stats.nextServiceDays }} zile</span>
-                  <span class="stat-card__sub">Est. {{ formatDate(stats.nextServiceDate) }}</span>
+                  <span class="stat-card__value">{{ 'maintenance.stats.inDays' | transloco:{ days: stats.nextServiceDays } }}</span>
+                  <span class="stat-card__sub">{{ 'maintenance.stats.estimated' | transloco:{ date: formatDate(stats.nextServiceDate) } }}</span>
                 } @else {
                   <span class="stat-card__value stat-card__value--empty">—</span>
                 }
@@ -119,15 +119,15 @@
         <div class="mn-tabs">
           <button class="mn-tab" [class.active]="activeTab === 'all'" (click)="setTab('all')">
             <ion-icon name="list-outline"></ion-icon>
-            Toate
+            {{ 'maintenance.tabs.all' | transloco }}
           </button>
           <button class="mn-tab" [class.active]="activeTab === 'upcoming'" (click)="setTab('upcoming')">
             <ion-icon name="time-outline"></ion-icon>
-            Viitoare
+            {{ 'maintenance.tabs.upcoming' | transloco }}
           </button>
           <button class="mn-tab" [class.active]="activeTab === 'history'" (click)="setTab('history')">
             <ion-icon name="calendar-outline"></ion-icon>
-            Istoric
+            {{ 'maintenance.tabs.history' | transloco }}
           </button>
         </div>
 
@@ -135,11 +135,11 @@
           @if (allRecords.length === 0) {
             <div class="mn-empty">
               <ion-icon name="construct-outline" class="mn-empty__icon"></ion-icon>
-              <h3 class="mn-empty__title">Nicio înregistrare</h3>
-              <p class="mn-empty__sub">Adaugă primul record de întreținere pentru {{ car.make }} {{ car.model }}.</p>
+              <h3 class="mn-empty__title">{{ 'maintenance.empty.noRecords' | transloco }}</h3>
+              <p class="mn-empty__sub">{{ 'maintenance.empty.noRecordsDesc' | transloco:{ name: car.make + ' ' + car.model } }}</p>
               <button class="btn-primary" (click)="addPanelOpen = true">
                 <ion-icon name="add-outline"></ion-icon>
-                Adaugă întreținere
+                {{ 'cars.details.addMaintenance' | transloco }}
               </button>
             </div>
           } @else {
@@ -154,9 +154,9 @@
                   @if (upcomingRecs.length > 0) {
                     <div class="mn-card">
                       <div class="mn-card__header">
-                        <h2 class="mn-card__title">Remindere viitoare</h2>
+                        <h2 class="mn-card__title">{{ 'maintenance.reminders.title' | transloco }}</h2>
                         @if (upcomingRecs.length > 3) {
-                          <button class="mn-card__link" (click)="setTab('upcoming')">Vezi toate</button>
+                          <button class="mn-card__link" (click)="setTab('upcoming')">{{ 'maintenance.reminders.viewAll' | transloco }}</button>
                         }
                       </div>
                       <ul class="reminder-list">
@@ -166,8 +166,8 @@
                               <ion-icon [name]="getCategoryConfig(rec.service_category).icon"></ion-icon>
                             </div>
                             <div class="reminder-item__body">
-                              <span class="reminder-item__name">{{ getCategoryConfig(rec.service_category).label }}</span>
-                              <span class="reminder-item__due">Scadent în <strong>{{ getDaysLeft(rec) }}</strong></span>
+                              <span class="reminder-item__name">{{ getCategoryConfig(rec.service_category).label | transloco }}</span>
+                              <span class="reminder-item__due" [innerHTML]="'maintenance.reminders.dueIn' | transloco:{ value: getDaysLeft(rec) }"></span>
                             </div>
                             @if (getPriorityLabel(rec); as badge) {
                               <span class="badge" [ngClass]="badge.css">{{ badge.label }}</span>
@@ -183,9 +183,9 @@
                 <div class="mn-card">
                   <div class="mn-card__header">
                     <h2 class="mn-card__title">
-                      @if (activeTab === 'upcoming') { Viitoare }
-                      @else if (activeTab === 'history') { Istoric întreținere }
-                      @else { Întreținere recentă }
+                      @if (activeTab === 'upcoming') { {{ 'maintenance.recordsCard.upcoming' | transloco }} }
+                      @else if (activeTab === 'history') { {{ 'maintenance.recordsCard.history' | transloco }} }
+                      @else { {{ 'maintenance.recordsCard.recent' | transloco }} }
                     </h2>
                   </div>
 
@@ -196,11 +196,11 @@
                     <table class="mn-table">
                       <thead>
                         <tr>
-                          <th>Serviciu / Piesă</th>
-                          <th>Dată</th>
-                          <th>Km</th>
-                          <th>Cost</th>
-                          <th>Note</th>
+                          <th>{{ 'maintenance.table.serviceItem' | transloco }}</th>
+                          <th>{{ 'maintenance.table.date' | transloco }}</th>
+                          <th>{{ 'maintenance.table.mileage' | transloco }}</th>
+                          <th>{{ 'maintenance.table.cost' | transloco }}</th>
+                          <th>{{ 'maintenance.table.notes' | transloco }}</th>
                           <th></th>
                         </tr>
                       </thead>
@@ -210,7 +210,7 @@
                             <td>
                               <div class="mn-table-cat">
                                 <span class="cat-dot" [ngClass]="'cat-dot--' + rec.service_category.toLowerCase()"></span>
-                                {{ getCategoryConfig(rec.service_category).label }}
+                                {{ getCategoryConfig(rec.service_category).label | transloco }}
                               </div>
                             </td>
                             <td>{{ formatDate(rec.service_date) }}</td>
@@ -218,14 +218,14 @@
                             <td>{{ rec.cost | number:'1.0-0' }} RON</td>
                             <td class="mn-table-notes">{{ rec.description }}</td>
                             <td>
-                              <button class="mn-del-btn" (click)="deleteRecord(rec.id)" title="Șterge">
+                              <button class="mn-del-btn" (click)="deleteRecord(rec.id)" [attr.title]="'common.delete' | transloco">
                                 <ion-icon name="trash-outline"></ion-icon>
                               </button>
                             </td>
                           </tr>
                         } @empty {
                           <tr>
-                            <td colspan="6" class="mn-table-empty">Nicio înregistrare pentru această filtrare</td>
+                            <td colspan="6" class="mn-table-empty">{{ 'maintenance.empty.noFilterMatch' | transloco }}</td>
                           </tr>
                         }
                       </tbody>
@@ -240,7 +240,7 @@
                           <ion-icon [name]="getCategoryConfig(rec.service_category).icon"></ion-icon>
                         </div>
                         <div class="mn-record-item__body">
-                          <span class="mn-record-item__name">{{ getCategoryConfig(rec.service_category).label }}</span>
+                          <span class="mn-record-item__name">{{ getCategoryConfig(rec.service_category).label | transloco }}</span>
                           <span class="mn-record-item__meta">
                             <ion-icon name="calendar-outline"></ion-icon>
                             {{ formatDate(rec.service_date) }} &nbsp;
@@ -262,7 +262,7 @@
                         </div>
                       </li>
                     } @empty {
-                      <li class="mn-record-empty">Nicio înregistrare</li>
+                      <li class="mn-record-empty">{{ 'maintenance.empty.noRecordsShort' | transloco }}</li>
                     }
                   </ul>
                 </div>
@@ -272,19 +272,19 @@
               <!-- SIDEBAR -->
               <div class="mn-side-col">
                 <div class="mn-card">
-                  <h2 class="mn-card__title mn-card__title--mb">Categorii service</h2>
+                  <h2 class="mn-card__title mn-card__title--mb">{{ 'maintenance.sidebar.categories' | transloco }}</h2>
                   <div class="cat-grid">
                     @for (cat of categories; track cat.value) {
                       <button class="cat-item" [class.active]="filterCategory === cat.value" (click)="toggleCategory(cat.value)">
                         <div class="cat-item__icon" [ngClass]="'ri-cat--' + cat.value.toLowerCase()">
                           <ion-icon [name]="cat.icon"></ion-icon>
                         </div>
-                        <span class="cat-item__label">{{ cat.label }}</span>
+                        <span class="cat-item__label">{{ cat.label | transloco }}</span>
                       </button>
                     }
                   </div>
                 </div>
-                <p class="mn-tip">Sfat: Ține întreținerea la zi pentru performanță optimă și valoare de revânzare mai bună.</p>
+                <p class="mn-tip">{{ 'maintenance.sidebar.tip' | transloco }}</p>
               </div>
 
             </div>
@@ -294,8 +294,8 @@
       } @else {
         <div class="mn-empty">
           <ion-icon name="car-outline" class="mn-empty__icon"></ion-icon>
-          <h3 class="mn-empty__title">Nicio mașină adăugată</h3>
-          <p class="mn-empty__sub">Adaugă mai întâi o mașină din secțiunea Garaj.</p>
+          <h3 class="mn-empty__title">{{ 'maintenance.empty.noVehicle' | transloco }}</h3>
+          <p class="mn-empty__sub">{{ 'maintenance.empty.noVehicleDesc' | transloco }}</p>
         </div>
       }
 

--- a/src/app/features/maintenance/maintenance.component.ts
+++ b/src/app/features/maintenance/maintenance.component.ts
@@ -13,6 +13,7 @@ import {
 } from 'ionicons/icons';
 import { map } from 'rxjs';
 import { UntilDestroy } from '@ngneat/until-destroy';
+import { TranslocoPipe, TranslocoService } from '@ngneat/transloco';
 
 export type Tab = 'all' | 'upcoming' | 'history';
 
@@ -23,17 +24,17 @@ export interface ServiceCategoryConfig {
 }
 
 export const CATEGORY_CONFIG: ServiceCategoryConfig[] = [
-  { value: 'OIL_CHANGE',           label: 'Ulei',       icon: 'water-outline' },
-  { value: 'BRAKE_SERVICE',        label: 'Frâne',      icon: 'build-outline' },
-  { value: 'TIRE_SERVICE',         label: 'Anvelope',   icon: 'settings-outline' },
-  { value: 'FLUID_SERVICE',        label: 'Lichide',    icon: 'color-filter-outline' },
-  { value: 'ENGINE_SERVICE',       label: 'Motor',      icon: 'construct-outline' },
-  { value: 'INSPECTION',           label: 'Inspecție',  icon: 'shield-checkmark-outline' },
-  { value: 'BATTERY_SERVICE',      label: 'Baterie',    icon: 'battery-charging-outline' },
-  { value: 'FILTER_SERVICE',       label: 'Filtre',     icon: 'list-outline' },
-  { value: 'LIGHT_SERVICE',        label: 'Lumini',     icon: 'flash-outline' },
-  { value: 'TRANSMISSION_SERVICE', label: 'Transmisie', icon: 'car-outline' },
-  { value: 'OTHER',                label: 'Altele',     icon: 'checkmark-circle-outline' },
+  { value: 'OIL_CHANGE',           label: 'maintenance.categories.oilChange',           icon: 'water-outline' },
+  { value: 'BRAKE_SERVICE',        label: 'maintenance.categories.brakeService',        icon: 'build-outline' },
+  { value: 'TIRE_SERVICE',         label: 'maintenance.categories.tireService',         icon: 'settings-outline' },
+  { value: 'FLUID_SERVICE',        label: 'maintenance.categories.fluidService',        icon: 'color-filter-outline' },
+  { value: 'ENGINE_SERVICE',       label: 'maintenance.categories.engineService',       icon: 'construct-outline' },
+  { value: 'INSPECTION',           label: 'maintenance.categories.inspection',          icon: 'shield-checkmark-outline' },
+  { value: 'BATTERY_SERVICE',      label: 'maintenance.categories.batteryService',      icon: 'battery-charging-outline' },
+  { value: 'FILTER_SERVICE',       label: 'maintenance.categories.filterService',       icon: 'list-outline' },
+  { value: 'LIGHT_SERVICE',        label: 'maintenance.categories.lightService',        icon: 'flash-outline' },
+  { value: 'TRANSMISSION_SERVICE', label: 'maintenance.categories.transmissionService', icon: 'car-outline' },
+  { value: 'OTHER',                label: 'maintenance.categories.other',               icon: 'checkmark-circle-outline' },
 ];
 
 @UntilDestroy()
@@ -41,7 +42,7 @@ export const CATEGORY_CONFIG: ServiceCategoryConfig[] = [
   selector: 'app-maintenance',
   templateUrl: 'maintenance.component.html',
   styleUrls: ['./maintenance.component.scss'],
-  imports: [AsyncPipe, DecimalPipe, NgClass, IonContent, IonIcon, IonSkeletonText, AddMaintenancePanelComponent],
+  imports: [AsyncPipe, DecimalPipe, NgClass, IonContent, IonIcon, IonSkeletonText, AddMaintenancePanelComponent, TranslocoPipe],
 })
 export class MaintenanceComponent implements OnInit {
   readonly cars$       = this._facade.cars$;
@@ -59,7 +60,10 @@ export class MaintenanceComponent implements OnInit {
 
   readonly categories = CATEGORY_CONFIG;
 
-  constructor(private readonly _facade: MaintenanceFacade) {
+  constructor(
+    private readonly _facade: MaintenanceFacade,
+    private readonly _transloco: TranslocoService,
+  ) {
     addIcons({
       addOutline, waterOutline, shieldCheckmarkOutline, settingsOutline,
       batteryChargingOutline, constructOutline, colorFilterOutline, flashOutline,
@@ -120,17 +124,19 @@ export class MaintenanceComponent implements OnInit {
   getPriorityLabel(record: MaintenanceRecordDto): { label: string; css: string } | null {
     if (!record.expiry_date) return null;
     const days = Math.ceil((new Date(record.expiry_date).getTime() - Date.now()) / 86400000);
-    if (days <= 0)  return { label: 'Expirat', css: 'badge--expired' };
-    if (days <= 14) return { label: 'Urgent',  css: 'badge--high' };
-    if (days <= 45) return { label: 'Mediu',   css: 'badge--medium' };
+    if (days <= 0)  return { label: this._transloco.translate('maintenance.priority.expired'), css: 'badge--expired' };
+    if (days <= 14) return { label: this._transloco.translate('maintenance.priority.urgent'),  css: 'badge--high' };
+    if (days <= 45) return { label: this._transloco.translate('maintenance.priority.medium'),  css: 'badge--medium' };
     return null;
   }
 
   getDaysLeft(record: MaintenanceRecordDto): string {
     if (!record.expiry_date) return '';
     const days = Math.ceil((new Date(record.expiry_date).getTime() - Date.now()) / 86400000);
-    if (days <= 0) return 'Expirat';
-    return days === 1 ? '1 zi' : `${days} zile`;
+    if (days <= 0) return this._transloco.translate('maintenance.daysLeft.expired');
+    return days === 1
+      ? this._transloco.translate('maintenance.daysLeft.oneDay')
+      : this._transloco.translate('maintenance.daysLeft.days', { count: days });
   }
 
   getCategoryConfig(cat: ServiceCategory): ServiceCategoryConfig {
@@ -144,7 +150,7 @@ export class MaintenanceComponent implements OnInit {
 
   formatDate(dateStr: string | null | undefined): string {
     if (!dateStr) return '—';
-    return new Date(dateStr).toLocaleDateString('ro-RO', { day: '2-digit', month: 'short', year: 'numeric' });
+    return new Date(dateStr).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
   }
 
   private _computeStats(records: MaintenanceRecordDto[]) {

--- a/src/app/features/maintenance/state/maintenance.state.ts
+++ b/src/app/features/maintenance/state/maintenance.state.ts
@@ -3,6 +3,7 @@ import { CarDto, CreateMaintenanceRecordDto, MaintenanceRecordDto } from '@hau/a
 import { CarService, MaintenanceRecordService } from '@hau/autogenapi/services';
 import { MaintenanceActions } from '@hau/features/maintenance/state/maintenance.actions';
 import { ToastController } from '@ionic/angular/standalone';
+import { TranslocoService } from '@ngneat/transloco';
 import { Action, Selector, State, StateContext } from '@ngxs/store';
 import { catchError, forkJoin, of, switchMap, take, tap } from 'rxjs';
 
@@ -28,6 +29,7 @@ export class MaintenanceState {
   private readonly _carService = inject(CarService);
   private readonly _maintenanceService = inject(MaintenanceRecordService);
   private readonly _toastCtrl = inject(ToastController);
+  private readonly _transloco = inject(TranslocoService);
 
   @Selector()
   static cars(s: MaintenanceStateModel): CarDto[] { return s.cars; }
@@ -118,7 +120,7 @@ export class MaintenanceState {
   async createRecordSuccess({ patchState, getState }: StateContext<MaintenanceStateModel>, { record }: MaintenanceActions.CreateRecordSuccess) {
     patchState({ submitting: false, records: [...getState().records, record] });
     const toast = await this._toastCtrl.create({
-      message: 'Înregistrarea a fost adăugată cu succes!',
+      message: this._transloco.translate('maintenance.toast.createSuccess'),
       duration: 2500,
       color: 'success',
       position: 'top',
@@ -130,7 +132,7 @@ export class MaintenanceState {
   async createRecordError({ patchState }: StateContext<MaintenanceStateModel>) {
     patchState({ submitting: false });
     const toast = await this._toastCtrl.create({
-      message: 'Eroare la adăugarea înregistrării. Încearcă din nou.',
+      message: this._transloco.translate('maintenance.toast.createError'),
       duration: 3000,
       color: 'danger',
       position: 'top',

--- a/src/app/features/overview/overview.component.html
+++ b/src/app/features/overview/overview.component.html
@@ -76,21 +76,21 @@
             <div class="deadline-badges">
               @if (row.rca) {
                 <div class="badge-group">
-                  <span class="doc-chip rca"><ion-icon name="shield"></ion-icon>{{ 'overview.deadlines.rca' | transloco }}</span>
+                  <span class="doc-chip rca"><ion-icon name="shield"></ion-icon>{{ 'overview.deadlines.insurance' | transloco }}</span>
                   <strong [class]="'badge-days ' + docUrgencyClass(row.rca.days)">{{ row.rca.days }}d</strong>
                   <span class="badge-date">{{ 'overview.deadlines.expires' | transloco }} {{ row.rca.dateStr }}</span>
                 </div>
               }
               @if (row.itp) {
                 <div class="badge-group">
-                  <span class="doc-chip itp"><ion-icon name="construct"></ion-icon>{{ 'overview.deadlines.itp' | transloco }}</span>
+                  <span class="doc-chip itp"><ion-icon name="construct"></ion-icon>{{ 'overview.deadlines.technicalInspection' | transloco }}</span>
                   <strong [class]="'badge-days ' + docUrgencyClass(row.itp.days)">{{ row.itp.days }}d</strong>
                   <span class="badge-date">{{ 'overview.deadlines.expires' | transloco }} {{ row.itp.dateStr }}</span>
                 </div>
               }
               @if (row.rov) {
                 <div class="badge-group">
-                  <span class="doc-chip rov"><ion-icon name="car"></ion-icon>{{ 'overview.deadlines.rov' | transloco }}</span>
+                  <span class="doc-chip rov"><ion-icon name="car"></ion-icon>{{ 'overview.deadlines.vignette' | transloco }}</span>
                   <strong [class]="'badge-days ' + docUrgencyClass(row.rov.days)">{{ row.rov.days }}d</strong>
                   <span class="badge-date">{{ 'overview.deadlines.expires' | transloco }} {{ row.rov.dateStr }}</span>
                 </div>
@@ -125,13 +125,13 @@
               </div>
               <div class="snapshot-chips">
                 @if (row.rca) {
-                  <span class="chip-sm rca"><ion-icon name="shield"></ion-icon>{{ 'overview.deadlines.rca' | transloco }} {{ row.rca.days }}d</span>
+                  <span class="chip-sm rca"><ion-icon name="shield"></ion-icon>{{ 'overview.deadlines.insurance' | transloco }} {{ row.rca.days }}d</span>
                 }
                 @if (row.itp) {
-                  <span class="chip-sm itp"><ion-icon name="construct"></ion-icon>{{ 'overview.deadlines.itp' | transloco }} {{ row.itp.days }}d</span>
+                  <span class="chip-sm itp"><ion-icon name="construct"></ion-icon>{{ 'overview.deadlines.technicalInspection' | transloco }} {{ row.itp.days }}d</span>
                 }
                 @if (row.rov) {
-                  <span class="chip-sm rov"><ion-icon name="car"></ion-icon>{{ 'overview.deadlines.rov' | transloco }} {{ row.rov.days }}d</span>
+                  <span class="chip-sm rov"><ion-icon name="car"></ion-icon>{{ 'overview.deadlines.vignette' | transloco }} {{ row.rov.days }}d</span>
                 }
               </div>
             </div>

--- a/src/app/shared/component/form-field/form-field.component.html
+++ b/src/app/shared/component/form-field/form-field.component.html
@@ -22,15 +22,15 @@
             />
             @if (uploadProgress) {
                 <ion-item>
-                    <ion-label>Uploading...</ion-label>
+                    <ion-label>{{ 'shared.formField.uploading' | transloco }}</ion-label>
                     <ion-progress-bar [value]="uploadProgress / 100"></ion-progress-bar>
                 </ion-item>
             }
             @if (control.errors?.['fileType']) {
-                <ion-note color="danger">Only image files are allowed!</ion-note>
+                <ion-note color="danger">{{ 'shared.formField.onlyImagesAllowed' | transloco }}</ion-note>
             }
             @if (control.errors?.['fileSize']) {
-                <ion-note color="danger">File size must be less than 1MB</ion-note>
+                <ion-note color="danger">{{ 'shared.formField.fileSizeLimit' | transloco }}</ion-note>
             }
         </div>
     }
@@ -54,7 +54,7 @@
                    type="text"
                    readonly
                    ngDefaultControl
-                   [placeholder]="'Select date'"></ion-input>
+                   [placeholder]="'common.selectDate' | transloco"></ion-input>
         <ion-modal [trigger]="datePickerId"
                    [keepContentsMounted]="true"
                    cssClass="hau-datepicker-modal">

--- a/src/app/shared/component/form-field/form-field.component.ts
+++ b/src/app/shared/component/form-field/form-field.component.ts
@@ -3,6 +3,7 @@ import { FormControl, NgControl, ReactiveFormsModule, ValidationErrors } from "@
 import { AbstractInputControlDirective } from "@hau/shared/directive/abstract-input-control.directive";
 import {IonDatetime, IonInput, IonItem, IonLabel, IonModal, IonProgressBar, IonNote, IonSelect, IonSelectOption} from '@ionic/angular/standalone';
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { TranslocoPipe } from '@ngneat/transloco';
 
 export interface InputErrorTranslation {
   key: string;
@@ -30,6 +31,7 @@ export interface OptionModel {
         IonNote,
         IonSelect,
         IonSelectOption,
+        TranslocoPipe,
     ],
     styleUrls: ['./form-field.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush

--- a/src/app/shared/component/photo-carousel/photo-carousel.component.html
+++ b/src/app/shared/component/photo-carousel/photo-carousel.component.html
@@ -63,7 +63,7 @@
             (click)="goTo(i)">
             <img [src]="photo.url | imageUrl" [alt]="altText" />
             @if (photo.isDefault) {
-              <span class="pc-thumb-badge">Main</span>
+              <span class="pc-thumb-badge">{{ 'shared.photoCarousel.main' | transloco }}</span>
             }
           </div>
         }
@@ -111,8 +111,8 @@
     }
 
     <div class="pc-lb-counter">
-      {{ activeIndex() + 1 }} / {{ photos.length }} &mdash; tap outside or
-      <span class="pc-lb-counter-close" (click)="closeLightbox()">close</span>
+      {{ activeIndex() + 1 }} / {{ photos.length }} &mdash; {{ 'shared.photoCarousel.tapOutsideOr' | transloco }}
+      <span class="pc-lb-counter-close" (click)="closeLightbox()">{{ 'common.close' | transloco }}</span>
     </div>
 
   </div>

--- a/src/app/shared/component/photo-carousel/photo-carousel.component.ts
+++ b/src/app/shared/component/photo-carousel/photo-carousel.component.ts
@@ -14,6 +14,7 @@ import { ImageUrlPipe } from '@hau/shared/pipes/image-url.pipe';
 import { IonIcon } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
 import { chevronBack, chevronForward, closeOutline, expandOutline } from 'ionicons/icons';
+import { TranslocoPipe } from '@ngneat/transloco';
 import Swiper from 'swiper';
 import { Navigation } from 'swiper/modules';
 
@@ -24,7 +25,7 @@ export interface PhotoItem { url: string; isDefault?: boolean; }
   templateUrl: './photo-carousel.component.html',
   styleUrls: ['./photo-carousel.component.scss'],
   standalone: true,
-  imports: [ImageUrlPipe, IonIcon],
+  imports: [ImageUrlPipe, IonIcon, TranslocoPipe],
 })
 export class PhotoCarouselComponent implements OnChanges, OnDestroy {
   @Input() photos: PhotoItem[] = [];

--- a/src/app/shared/component/vehicle-catalog-select/vehicle-catalog-select.component.html
+++ b/src/app/shared/component/vehicle-catalog-select/vehicle-catalog-select.component.html
@@ -4,7 +4,7 @@
 
     <!-- Make combobox -->
     <div class="cs-wrap" [class.cs-wrap--open]="makeOpen" [class.cs-wrap--disabled]="makesLoading">
-      <label class="cs-label" [class.cs-label--up]="makeSearch || makeOpen">Make *</label>
+      <label class="cs-label" [class.cs-label--up]="makeSearch || makeOpen">{{ 'shared.vehicleCatalogSelect.make' | transloco }} *</label>
       <div class="cs-field">
         <input
           class="cs-input"
@@ -34,7 +34,7 @@
               </button>
             }
           } @else {
-            <div class="cs-no-results">No makes found</div>
+            <div class="cs-no-results">{{ 'shared.vehicleCatalogSelect.noMakesFound' | transloco }}</div>
           }
         </div>
       }
@@ -42,7 +42,7 @@
 
     <!-- Model combobox -->
     <div class="cs-wrap" [class.cs-wrap--open]="modelOpen" [class.cs-wrap--disabled]="!selectedMakeId || modelsLoading">
-      <label class="cs-label" [class.cs-label--up]="modelSearch || modelOpen || !selectedMakeId">Model *</label>
+      <label class="cs-label" [class.cs-label--up]="modelSearch || modelOpen || !selectedMakeId">{{ 'shared.vehicleCatalogSelect.model' | transloco }} *</label>
       <div class="cs-field">
         <input
           class="cs-input"
@@ -51,7 +51,7 @@
           (input)="onModelInput()"
           (focus)="openModelDropdown()"
           [disabled]="!selectedMakeId || modelsLoading"
-          [placeholder]="!selectedMakeId ? 'Select make first' : (modelsLoading ? 'Loading…' : '')"
+          [placeholder]="!selectedMakeId ? ('shared.vehicleCatalogSelect.selectMakeFirst' | transloco) : (modelsLoading ? ('common.loading' | transloco) : '')"
           autocomplete="off"
           spellcheck="false">
         @if (modelsLoading) {
@@ -73,7 +73,7 @@
               </button>
             }
           } @else {
-            <div class="cs-no-results">No models found</div>
+            <div class="cs-no-results">{{ 'shared.vehicleCatalogSelect.noModelsFound' | transloco }}</div>
           }
         </div>
       }
@@ -85,7 +85,7 @@
 
     <!-- Year combobox -->
     <div class="cs-wrap" [class.cs-wrap--open]="yearOpen">
-      <label class="cs-label" [class.cs-label--up]="yearSearch || yearOpen">Year *</label>
+      <label class="cs-label" [class.cs-label--up]="yearSearch || yearOpen">{{ 'shared.vehicleCatalogSelect.year' | transloco }} *</label>
       <div class="cs-field">
         <input
           class="cs-input"
@@ -112,7 +112,7 @@
               </button>
             }
           } @else {
-            <div class="cs-no-results">No years found</div>
+            <div class="cs-no-results">{{ 'shared.vehicleCatalogSelect.noYearsFound' | transloco }}</div>
           }
         </div>
       }

--- a/src/app/shared/component/vehicle-catalog-select/vehicle-catalog-select.component.ts
+++ b/src/app/shared/component/vehicle-catalog-select/vehicle-catalog-select.component.ts
@@ -13,6 +13,7 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { IonIcon, IonSpinner } from '@ionic/angular/standalone';
+import { TranslocoPipe } from '@ngneat/transloco';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { VehicleCatalogService } from '@hau/autogenapi/services';
 import { MakeResponseDto, ModelResponseDto } from '@hau/autogenapi/models';
@@ -28,7 +29,7 @@ export interface CatalogSelection {
   selector: 'app-vehicle-catalog-select',
   templateUrl: './vehicle-catalog-select.component.html',
   styleUrls: ['./vehicle-catalog-select.component.scss'],
-  imports: [FormsModule, IonIcon, IonSpinner],
+  imports: [FormsModule, IonIcon, IonSpinner, TranslocoPipe],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class VehicleCatalogSelectComponent implements OnInit, OnChanges {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1,5 +1,30 @@
 {
   "homepage": "History Auto Utility",
+  "app": {
+    "redirecting": "Redirecting…"
+  },
+  "common": {
+    "soon": "Soon",
+    "cancel": "Cancel",
+    "save": "Save",
+    "saving": "Saving…",
+    "edit": "Edit",
+    "delete": "Delete",
+    "view": "View",
+    "back": "Back",
+    "loading": "Loading…",
+    "close": "Close",
+    "confirm": "Confirm",
+    "yes": "Yes",
+    "no": "No",
+    "actions": "Actions",
+    "more": "More",
+    "search": "Search",
+    "share": "Share",
+    "remove": "Remove",
+    "selectDate": "Select date",
+    "noData": "—"
+  },
   "overview": {
     "title": "Overview",
     "subtitle": "Your fleet status at a glance",
@@ -16,9 +41,9 @@
     },
     "deadlines": {
       "title": "Upcoming deadlines",
-      "rca": "RCA",
-      "itp": "ITP",
-      "rov": "ROV",
+      "insurance": "MTPL",
+      "technicalInspection": "Inspection",
+      "vignette": "Vignette",
       "expires": "Expires",
       "noDocs": "No documents added"
     },
@@ -67,7 +92,12 @@
     },
     "addVehicle": "Add vehicle",
     "settings": "Settings",
-    "logout": "Logout"
+    "logout": "Logout",
+    "language": "Language",
+    "version": {
+      "upToDate": "You're up to date",
+      "updateAvailable": "Update available"
+    }
   },
   "blog": {
     "title": "Blog",
@@ -78,51 +108,80 @@
       "vehicle": "Vehicle Journal"
     },
     "filters": {
+      "all": "All",
+      "more": "More",
       "allTags": "All tags",
       "newestFirst": "Newest first",
       "oldestFirst": "Oldest first",
       "search": "Search entries"
     },
+    "newEntryOptions": {
+      "personal": "Personal entry",
+      "vehicle": "Vehicle Journal"
+    },
     "sections": {
       "pinned": "Pinned",
       "allEntries": "All entries"
     },
+    "noMoreEntries": "No more entries",
+    "notFound": "Entry not found.",
+    "backToBlog": "Back to Blog",
+    "writeHeading": {
+      "edit": "Edit Entry",
+      "new": "New Entry"
+    },
+    "confirmCancel": {
+      "title": "Unsaved changes",
+      "body": "You have unsaved changes. Would you like to save before leaving?",
+      "discard": "Discard & leave",
+      "keepEditing": "Keep editing"
+    },
     "entry": {
-      "edit": "Edit",
       "pin": "Pin",
       "unpin": "Unpin",
-      "share": "Share",
-      "delete": "Delete",
-      "back": "Back",
       "save": "Save entry",
-      "cancel": "Cancel",
       "draftSaved": "Draft saved"
     },
     "form": {
       "category": "Category",
+      "selectCategory": "Select category",
       "vehicle": "Vehicle",
+      "selectVehicle": "Select vehicle",
       "entryType": "Entry type",
       "mileage": "Mileage (km)",
-      "cost": "Cost (RON)",
+      "mileagePlaceholder": "e.g. 184 200",
+      "cost": "Price / Cost (RON)",
+      "optionalPlaceholder": "Optional",
       "date": "Date",
       "title": "Title",
+      "titleRequired": "Title is required",
       "titlePlaceholder": "Give your entry a title",
       "vjTitlePlaceholder": "Brief description of the event",
       "tags": "Tags",
       "tagsHint": "Press Enter or comma to add a tag",
+      "addTag": "Add tag",
       "content": "Content",
       "contentPlaceholder": "Write your story here…",
+      "notesStory": "Notes / Story",
       "vjContentPlaceholder": "Describe what happened, what you noticed, what was replaced…",
       "coverImage": "Cover image",
       "coverImageOptional": "optional",
       "coverImageUpload": "Upload cover image",
+      "coverAlt": "Cover",
+      "photos": "Photos",
+      "uploadPhotos": "Upload photos",
+      "photoHint": "PNG, JPG up to 10 MB",
       "status": "Status",
       "statusDraft": "Draft",
       "statusPublished": "Published",
       "saveDraft": "Save draft",
-      "publish": "Publish"
+      "publish": "Publish",
+      "saved": "Saved",
+      "details": "Details",
+      "next": "Next"
     },
     "editor": {
+      "toolbarLabel": "Editor toolbar",
       "bold": "Bold",
       "italic": "Italic",
       "heading2": "Heading 2",
@@ -148,12 +207,59 @@
       "draft": "Draft",
       "published": "Published"
     },
-    "empty": "No entries yet. Start writing!"
+    "empty": {
+      "personal": "No entries yet. Start writing!",
+      "vehicle": "No entries for this vehicle yet."
+    }
+  },
+  "login": {
+    "trustBadge": "Trusted by vehicle owners",
+    "headline": "Manage your vehicles<br>with confidence",
+    "heroDesc": "Track documents, maintenance, and important deadlines so your vehicles stay road-ready and worry-free.",
+    "card": {
+      "title": "Welcome back",
+      "subtitle": "Sign in securely with your Google account",
+      "googleButton": "Continue with Google",
+      "or": "or",
+      "privacyLine": "Secure, private, and easy to use.",
+      "privacyLineMuted": "We never access or share your Google data."
+    },
+    "features": {
+      "privacy": {
+        "title": "Your data stays private",
+        "desc": "We respect your privacy and keep your data safe."
+      },
+      "security": {
+        "title": "Secure by design",
+        "desc": "Enterprise-grade security to protect what matters."
+      },
+      "oneAccount": {
+        "title": "One account for all vehicles",
+        "desc": "Access all your vehicles and data in one place."
+      }
+    },
+    "footer": {
+      "copyright": "© 2026 History Auto Utility. All rights reserved.",
+      "privacyPolicy": "Privacy Policy",
+      "termsOfService": "Terms of Service"
+    },
+    "preview": {
+      "vehiclesCount": "3 vehicles",
+      "documentsExpireSoon": "2 documents expire soon",
+      "oilServiceIn": "Oil service in <strong>1,250 km</strong>",
+      "stats": {
+        "documentsExpiring": "Documents expiring"
+      },
+      "documentsUpdated": "Documents updated",
+      "insuranceDocument": "Insurance document",
+      "todayAt": "Today, 10:24 AM"
+    }
   },
   "documents": {
     "title": "Documents",
     "subtitle": "All documents for your vehicles",
     "addDocument": "Add document",
+    "loading": "Loading documents…",
     "filters": {
       "allVehicles": "All vehicles",
       "allTypes": "All document types",
@@ -175,45 +281,458 @@
       "noExpiry": "No expiry"
     },
     "types": {
-      "RCA": "Insurance (RCA)",
-      "ITP": "ITP Certificate",
-      "ROV": "ROV Certificate",
+      "RCA": "Liability Insurance (RCA)",
+      "ITP": "Technical Inspection (ITP)",
+      "ROV": "Road Vignette (ROV)",
       "REGISTRATION": "Registration Certificate",
       "ROAD_TAX": "Road Tax"
     },
-    "actions": {
-      "view": "View",
-      "edit": "Edit",
-      "delete": "Delete"
+    "typeAbbr": {
+      "RCA": "INS",
+      "ITP": "INSP",
+      "ROV": "VIG",
+      "REGISTRATION": "REG",
+      "ROAD_TAX": "TAX"
     },
     "empty": {
       "noDocuments": "No documents yet. Add your first document.",
       "noResults": "No documents match your filters."
     },
     "footer": {
-      "showing": "Showing {{from}} to {{to}} of {{total}} documents"
+      "showing": "Showing {{from}} to {{to}} of {{total}} documents",
+      "showingShort": "Showing {{count}} of {{total}} documents"
+    },
+    "form": {
+      "editTitle": "Edit Document",
+      "addTitle": "Add Document",
+      "editSubtitle": "Update the document details below.",
+      "addSubtitle": "Fill in the document details below.",
+      "basicInfo": "Basic information",
+      "fields": {
+        "documentType": "Document type",
+        "provider": "Provider",
+        "policyNumber": "Policy number",
+        "issueDate": "Issue date",
+        "expiryDate": "Expiry date",
+        "policyholder": "Policyholder",
+        "cnpId": "CNP / ID"
+      },
+      "placeholders": {
+        "provider": "e.g. Allianz-Tiriac",
+        "policyNumber": "e.g. POL-123456789",
+        "policyholder": "e.g. John Doe",
+        "cnpId": "e.g. 1900101012345"
+      },
+      "selectType": "Select type",
+      "selectVehicle": "Select vehicle",
+      "errors": {
+        "documentTypeRequired": "Document type is required.",
+        "vehicleRequired": "Vehicle is required."
+      },
+      "statusOptions": {
+        "active": "Active",
+        "inactive": "Inactive",
+        "expired": "Expired"
+      },
+      "validity": "Validity",
+      "noExpirySuffix": "— no expiry",
+      "noExpiryCheckbox": "This document has no expiry date",
+      "documentFile": "Document file",
+      "dragDrop": "Drag & drop",
+      "dragDropHere": "your document here",
+      "uploadHint": "or click to browse · PDF, JPG, PNG up to 20 MB",
+      "currentFile": "Current file: {{name}}",
+      "analysingDocument": "Analysing your document…",
+      "additionalDetails": "Additional details",
+      "uploading": "Uploading…",
+      "saveChanges": "Save changes",
+      "extraction": {
+        "failedTitle": "Could not read the document",
+        "notRecognisedTitle": "Document type not recognised",
+        "highConfidenceTitle": "Fields pre-filled from your document",
+        "lowConfidenceTitle": "Fields extracted with lower confidence",
+        "failedDesc": "The document could not be analysed. Please fill in the fields manually.",
+        "notRecognisedDesc": "We could not identify this document type. Please fill in the fields manually.",
+        "highConfidenceDesc": "Please review the pre-filled values and correct any errors before saving.",
+        "lowConfidenceDesc": "Some values may be inaccurate — please verify all fields carefully before saving."
+      }
+    },
+    "detail": {
+      "documentInfo": "Document information",
+      "validFrom": "Valid from",
+      "expiring": "Expiring",
+      "documentFile": "Document file",
+      "documentPreview": "Document preview",
+      "document": "Document",
+      "download": "Download",
+      "extractedInfo": "Extracted information",
+      "extractedInfoNote": "Information extracted automatically from the document. You can edit if needed."
+    }
+  },
+  "maintenance": {
+    "title": "Maintenance",
+    "subtitle": "Track service history, upcoming tasks, and vehicle care.",
+    "toast": {
+      "createSuccess": "Record added successfully!",
+      "createError": "Error adding the record. Please try again."
+    },
+    "stats": {
+      "lastOilChange": "Last oil change",
+      "at": "at {{ value }}",
+      "totalRecords": "Total records",
+      "entries": "maintenance entries",
+      "nextService": "Next service",
+      "inDays": "In {{ days }} days",
+      "estimated": "Est. {{ date }}"
+    },
+    "tabs": {
+      "all": "All",
+      "upcoming": "Upcoming",
+      "history": "History"
+    },
+    "empty": {
+      "noRecords": "No records yet",
+      "noRecordsDesc": "Add the first maintenance record for {{ name }}.",
+      "noFilterMatch": "No records match this filter",
+      "noRecordsShort": "No records",
+      "noVehicle": "No vehicle added",
+      "noVehicleDesc": "Add a vehicle from the Garage section first."
+    },
+    "reminders": {
+      "title": "Upcoming reminders",
+      "viewAll": "View all",
+      "dueIn": "Due in <strong>{{ value }}</strong>"
+    },
+    "recordsCard": {
+      "upcoming": "Upcoming",
+      "history": "Maintenance history",
+      "recent": "Recent maintenance"
+    },
+    "table": {
+      "serviceItem": "Service / Part",
+      "date": "Date",
+      "mileage": "Mileage",
+      "cost": "Cost",
+      "notes": "Notes"
+    },
+    "sidebar": {
+      "categories": "Service categories",
+      "tip": "Tip: Keep maintenance up to date for optimal performance and better resale value."
+    },
+    "priority": {
+      "expired": "Expired",
+      "urgent": "Urgent",
+      "medium": "Medium"
+    },
+    "daysLeft": {
+      "expired": "Expired",
+      "oneDay": "1 day",
+      "days": "{{ count }} days"
+    },
+    "categories": {
+      "oilChange": "Oil",
+      "brakeService": "Brakes",
+      "tireService": "Tires",
+      "fluidService": "Fluids",
+      "engineService": "Engine",
+      "inspection": "Inspection",
+      "batteryService": "Battery",
+      "filterService": "Filters",
+      "lightService": "Lights",
+      "transmissionService": "Transmission",
+      "other": "Other"
+    },
+    "form": {
+      "title": "Add maintenance",
+      "subtitle": "Log a service or repair",
+      "fields": {
+        "vehicle": "Vehicle",
+        "serviceDate": "Service date",
+        "mileage": "Mileage",
+        "category": "Category",
+        "type": "Type",
+        "description": "Description / Parts",
+        "cost": "Cost (RON)",
+        "expiryDate": "Expiry / reminder date"
+      },
+      "placeholders": {
+        "mileage": "e.g. 51000",
+        "description": "e.g. 10W40 oil, MANN air filter, oil filter",
+        "cost": "e.g. 250"
+      },
+      "serviceTypes": {
+        "maintenance": "Maintenance",
+        "repair": "Repair",
+        "improvement": "Improvement"
+      }
+    }
+  },
+  "cars": {
+    "toast": {
+      "createSuccess": "Vehicle added successfully!",
+      "updateSuccess": "Vehicle updated successfully!",
+      "deleteSuccess": "Vehicle deleted successfully!",
+      "markSoldSuccess": "Vehicle marked as sold.",
+      "restoreSuccess": "Vehicle restored to garage.",
+      "genericError": "Something went wrong. Please try again."
+    },
+    "details": {
+      "breadcrumb": {
+        "garage": "Garage",
+        "formerVehicles": "Former vehicles",
+        "viewDetails": "View details"
+      },
+      "archivedOn": "Archived on {{date}}",
+      "vehicleDetails": "Vehicle details",
+      "vehicleOverview": "Vehicle overview",
+      "subtitle": "Complete vehicle profile, documents, deadlines, and maintenance history.",
+      "fields": {
+        "make": "Make",
+        "model": "Model",
+        "year": "Year",
+        "vin": "VIN",
+        "variant": "Variant / Trim",
+        "fuelType": "Fuel type",
+        "transmission": "Transmission",
+        "finalMileage": "Final mileage",
+        "ownedSince": "Owned since",
+        "ownershipStartDate": "Ownership start date"
+      },
+      "removeFromArchive": "Remove from archive",
+      "removeFromGarage": "Remove from garage",
+      "editVehicle": "Edit vehicle",
+      "shareVehicle": "Share vehicle",
+      "addMaintenance": "Add maintenance",
+      "uploadDocument": "Upload document",
+      "removeAccess": "Remove access",
+      "sheet": {
+        "shareVehicleDesc": "Invite others to view or manage",
+        "addMaintenanceDesc": "Log a service or repair record",
+        "uploadDocumentDesc": "Add RCA, ITP or other documents",
+        "removeAccessDesc": "Leave this shared vehicle"
+      },
+      "nextKeyExpiry": "Next key expiry",
+      "documentsAndDeadlines": "Documents & deadlines",
+      "docItem": {
+        "insuranceExpiry": "Insurance expiry date",
+        "inspectionExpiry": "Inspection expiry date",
+        "vignetteExpiry": "Vignette expiry date",
+        "daysLeft": "{{days}}d left"
+      },
+      "maintenanceHistory": {
+        "title": "Repairs & maintenance history",
+        "totalRecords": "Total records",
+        "totalSpent": "Total spent",
+        "lastService": "Last service",
+        "nextOilService": "Next oil service",
+        "empty": "No maintenance records yet",
+        "table": {
+          "date": "Date",
+          "mileage": "Mileage",
+          "category": "Category",
+          "workPerformed": "Work performed",
+          "cost": "Cost",
+          "notes": "Notes"
+        }
+      },
+      "deleteAlert": {
+        "header": "Delete permanently?",
+        "message": "All data for <strong>{{name}}</strong> will be permanently deleted and cannot be recovered."
+      }
+    },
+    "form": {
+      "editVehicle": "Edit vehicle",
+      "addVehicle": "Add vehicle",
+      "editSubtitle": "Update your vehicle's details, documents, and photos.",
+      "addSubtitle": "Fill in your vehicle's details to add it to your garage.",
+      "fields": {
+        "nickname": "Nickname",
+        "engine": "Engine",
+        "color": "Color",
+        "initialMileage": "Initial mileage (km)"
+      },
+      "coreDetailsNote": "These details help us identify your vehicle and personalize your experience.",
+      "additionalInfo": {
+        "title": "Additional vehicle info",
+        "desc": "Variant, VIN, fuel type, and more"
+      },
+      "quickTips": {
+        "title": "Quick tips",
+        "dismiss": "Dismiss quick tips",
+        "tip1": "Add a nickname to easily recognize your vehicle at a glance.",
+        "tip2": "Upload a photo to make your garage feel more personal.",
+        "tip3": "Enter the initial mileage for more accurate service reminders.",
+        "tip4": "You can always come back and complete the rest later."
+      },
+      "additionalBadge": {
+        "filled": "{{count}} / {{total}} filled",
+        "empty": "{{total}} fields · optional"
+      },
+      "documentsBadge": {
+        "set": "Set",
+        "optional": "Optional"
+      },
+      "mileageAlert": {
+        "header": "No mileage entered",
+        "message": "Adding the current mileage helps us track maintenance and give you accurate reminders. Continue without it?",
+        "addMileage": "Add mileage",
+        "continueWithoutIt": "Continue without it"
+      },
+      "deleteAlert": {
+        "fallbackName": "this vehicle"
+      },
+      "mileageHint": {
+        "title": "Initial mileage is recommended.",
+        "desc": "It improves maintenance tracking, service reminders, and report accuracy. You can still continue without it."
+      },
+      "documentsSection": {
+        "desc": "Oil service tracking — documents are managed in the Documents section"
+      },
+      "photos": {
+        "title": "Photos",
+        "subtitle": "Add photos of your vehicle. Click a photo to set it as default. You can upload more later.",
+        "uploadLabel": "Upload photos",
+        "defaultPhoto": "Default photo",
+        "setAsDefault": "Click to set as default",
+        "defaultBadge": "Default",
+        "limitReached": "Maximum of {{max}} photos reached. Remove a photo to add more."
+      },
+      "actionBar": {
+        "saving": "Saving...",
+        "adding": "Adding...",
+        "update": "Update vehicle",
+        "save": "Save vehicle",
+        "saveAndAddAnother": "Save & add another"
+      }
+    },
+    "shareVehicle": {
+      "subtitle": "Manage who can access {{name}}",
+      "inviteUser": "Invite user",
+      "emailAddress": "Email address",
+      "sending": "Sending…",
+      "sendInvite": "Send invite",
+      "inviteError": "Could not send invitation.",
+      "peopleWithAccess": "People with access",
+      "pending": "Pending",
+      "roles": {
+        "owner": "Owner",
+        "full": "Full",
+        "user": "User",
+        "maintenance": "Maintenance",
+        "viewer": "Viewer"
+      }
+    },
+    "removePanel": {
+      "titleSold": "Manage archived vehicle",
+      "titleActive": "Remove from garage",
+      "subtitle": "What do you want to do with <strong>{{name}}</strong>?",
+      "restore": {
+        "title": "Add back to garage",
+        "desc": "Restore as an active vehicle. All history preserved."
+      },
+      "markSold": {
+        "title": "Mark as sold",
+        "desc": "Archived in Former vehicles. All history preserved, read-only."
+      },
+      "deletePermanently": {
+        "title": "Delete permanently",
+        "desc": "All data deleted. This cannot be undone."
+      }
+    },
+    "list": {
+      "cardsView": "Cards view",
+      "listView": "List view",
+      "cards": "Cards",
+      "list": "List",
+      "loading": "Loading cars…",
+      "sharedWithMe": "Shared with me",
+      "formerVehicles": "Former vehicles",
+      "sold": "Sold",
+      "empty": {
+        "title": "Your garage is empty",
+        "description": "Add your first vehicle to start tracking documents, maintenance, and important deadlines.",
+        "addFirst": "Add your first vehicle",
+        "howItWorks": "How it works",
+        "hint": "You can always add more vehicles later.",
+        "gettingStarted": {
+          "title": "Getting started",
+          "step1Title": "Add your vehicle details",
+          "step1Desc": "Basic info like make, model, and year",
+          "step2Title": "Upload registration and insurance documents",
+          "step2Desc": "We'll keep them safe and organized",
+          "step3Title": "Set service and inspection dates",
+          "step3Desc": "Get reminders before it's due"
+        },
+        "unlock": {
+          "title": "What you unlock",
+          "docsTitle": "Document reminders",
+          "docsDesc": "Never miss an expiry again",
+          "serviceTitle": "Service history",
+          "serviceDesc": "Track all maintenance in one place",
+          "deadlinesTitle": "Upcoming deadlines",
+          "deadlinesDesc": "Stay ahead of important tasks"
+        },
+        "tip": {
+          "label": "Tip:",
+          "text": "Start with your most-used car and add the rest later.",
+          "subtext": "You're in control."
+        }
+      }
     }
   },
   "car": {
     "viewDetails": "View Details",
-    "edit": "Edit",
     "licensePlate": "License Plate",
+    "fields": {
+      "oilService": "Oil service",
+      "lastOilService": "Last oil service",
+      "lastOilServiceDate": "Last oil service date",
+      "lastOilServiceMileage": "Last oil service mileage",
+      "ownershipSince": "Ownership since",
+      "initialMileage": "Initial mileage",
+      "currentMileage": "Current mileage"
+    },
     "documents": {
-      "rca": {
-        "label": "RCA",
-        "tooltip": "RCA — Civil Liability Insurance",
+      "item": {
+        "insurance": "Insurance",
+        "issueDate": "Issue date",
+        "expiryDate": "Expiry date"
+      },
+      "insurance": {
+        "label": "MTPL",
+        "tooltip": "MTPL — Motor Third-Party Liability Insurance (RCA)",
         "expires": "Expires in {{days}} days"
       },
-      "itp": {
-        "label": "ITP",
-        "tooltip": "ITP — Periodic Technical Inspection",
+      "technicalInspection": {
+        "label": "Inspection",
+        "tooltip": "Periodic Technical Inspection (ITP)",
         "expires": "Expires in {{days}} days"
       },
-      "rov": {
-        "label": "ROV",
-        "tooltip": "ROV — Road Tax / Vignette",
+      "vignette": {
+        "label": "Vignette",
+        "tooltip": "Road Vignette / Toll Sticker (ROV)",
         "expires": "Expires in {{days}} days"
       }
+    }
+  },
+  "shared": {
+    "photoCarousel": {
+      "main": "Main",
+      "tapOutsideOr": "Tap outside or press"
+    },
+    "formField": {
+      "uploading": "Uploading…",
+      "onlyImagesAllowed": "Only image files are allowed!",
+      "fileSizeLimit": "File size must be less than 1MB"
+    },
+    "vehicleCatalogSelect": {
+      "make": "Make",
+      "model": "Model",
+      "year": "Year",
+      "noMakesFound": "No makes found",
+      "noModelsFound": "No models found",
+      "noYearsFound": "No years found",
+      "selectMakeFirst": "Select a make first"
     }
   }
 }

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -1,0 +1,738 @@
+{
+  "homepage": "History Auto Utility",
+  "app": {
+    "redirecting": "Se redirecționează…"
+  },
+  "common": {
+    "soon": "În curând",
+    "cancel": "Anulează",
+    "save": "Salvează",
+    "saving": "Se salvează…",
+    "edit": "Editează",
+    "delete": "Șterge",
+    "view": "Vezi",
+    "back": "Înapoi",
+    "loading": "Se încarcă…",
+    "close": "Închide",
+    "confirm": "Confirmă",
+    "yes": "Da",
+    "no": "Nu",
+    "actions": "Acțiuni",
+    "more": "Mai multe",
+    "search": "Caută",
+    "share": "Partajează",
+    "remove": "Elimină",
+    "selectDate": "Selectează data",
+    "noData": "—"
+  },
+  "overview": {
+    "title": "Prezentare generală",
+    "subtitle": "Starea flotei tale dintr-o privire",
+    "viewAll": "Vezi tot",
+    "stats": {
+      "vehicles": "Vehicule",
+      "vehiclesSub": "Total în garaj",
+      "docsExpiring": "Documente care expiră curând",
+      "docsExpiringSub": "Necesită atenție",
+      "upcomingService": "Service apropiat",
+      "upcomingServiceSub": "Următoarele 30 de zile",
+      "alerts": "Alerte active",
+      "alertsSub": "Necesită acțiune"
+    },
+    "deadlines": {
+      "title": "Termene apropiate",
+      "insurance": "RCA",
+      "technicalInspection": "ITP",
+      "vignette": "Rovinietă",
+      "expires": "Expiră",
+      "noDocs": "Nu există documente adăugate"
+    },
+    "garage": {
+      "title": "Imagine garaj"
+    },
+    "expiring": {
+      "title": "Expiră curând",
+      "empty": "Toate documentele sunt la zi",
+      "expired": "Expirat"
+    },
+    "actions": {
+      "title": "Acțiuni rapide",
+      "addVehicle": "Adaugă vehicul",
+      "addVehicleSub": "Adaugă un vehicul nou în garaj",
+      "uploadDoc": "Încarcă document",
+      "uploadDocSub": "Adaugă sau actualizează documentele vehiculului",
+      "logMaintenance": "Adaugă mentenanță",
+      "logMaintenanceSub": "Înregistrează o lucrare de service sau reparație",
+      "checkDeadlines": "Verifică termenele",
+      "checkDeadlinesSub": "Revizuiește expirările apropiate"
+    }
+  },
+  "sidebar": {
+    "slogan": "Îngrijirea vehiculului, simplificată",
+    "myGarage": "Garajul meu",
+    "myGarageVehicles": "{{count}} deținute",
+    "sharedVehicles": "{{count}} partajate",
+    "garageSubtitle": "Vehiculele tale dintr-o privire",
+    "mainSection": "Principal",
+    "nav": {
+      "overview": "Prezentare generală",
+      "garage": "Garaj",
+      "documents": "Documente",
+      "maintenance": "Mentenanță",
+      "reports": "Rapoarte",
+      "blog": "Blog"
+    },
+    "attention": {
+      "title": "Necesită atenție",
+      "expiresIn": "expiră în {{days}} zile"
+    },
+    "invites": {
+      "title": "{{count}} invitație în așteptare",
+      "accept": "Acceptă"
+    },
+    "addVehicle": "Adaugă vehicul",
+    "settings": "Setări",
+    "logout": "Deconectare",
+    "language": "Limbă",
+    "version": {
+      "upToDate": "Ai cea mai recentă versiune",
+      "updateAvailable": "Actualizare disponibilă"
+    }
+  },
+  "blog": {
+    "title": "Blog",
+    "subtitle": "Poveștile, experiențele și jurnalul mașinii tale",
+    "newEntry": "Intrare nouă",
+    "tabs": {
+      "personal": "Personal",
+      "vehicle": "Jurnal vehicul"
+    },
+    "filters": {
+      "allTags": "Toate etichetele",
+      "newestFirst": "Cele mai noi primele",
+      "oldestFirst": "Cele mai vechi primele",
+      "search": "Caută intrări",
+      "all": "Toate",
+      "more": "Mai multe"
+    },
+    "sections": {
+      "pinned": "Fixate",
+      "allEntries": "Toate intrările"
+    },
+    "entry": {
+      "pin": "Fixează",
+      "unpin": "Anulează fixarea",
+      "save": "Salvează intrarea",
+      "draftSaved": "Ciorna a fost salvată"
+    },
+    "form": {
+      "category": "Categorie",
+      "vehicle": "Vehicul",
+      "entryType": "Tip intrare",
+      "mileage": "Kilometraj (km)",
+      "cost": "Cost (RON)",
+      "date": "Dată",
+      "title": "Titlu",
+      "titlePlaceholder": "Dă un titlu intrării tale",
+      "vjTitlePlaceholder": "Descriere scurtă a evenimentului",
+      "tags": "Etichete",
+      "tagsHint": "Apasă Enter sau virgulă pentru a adăuga o etichetă",
+      "content": "Conținut",
+      "contentPlaceholder": "Scrie povestea ta aici…",
+      "vjContentPlaceholder": "Descrie ce s-a întâmplat, ce ai observat, ce a fost înlocuit…",
+      "coverImage": "Imagine copertă",
+      "coverImageOptional": "opțional",
+      "coverImageUpload": "Încarcă imagine copertă",
+      "status": "Status",
+      "statusDraft": "Ciornă",
+      "statusPublished": "Publicat",
+      "saveDraft": "Salvează ciorna",
+      "publish": "Publică",
+      "selectCategory": "Selectează categoria",
+      "selectVehicle": "Selectează vehiculul",
+      "mileagePlaceholder": "ex. 184 200",
+      "optionalPlaceholder": "Opțional",
+      "titleRequired": "Titlul este obligatoriu",
+      "addTag": "Adaugă etichetă",
+      "notesStory": "Notițe / Poveste",
+      "coverAlt": "Copertă",
+      "photos": "Fotografii",
+      "uploadPhotos": "Încarcă fotografii",
+      "photoHint": "PNG, JPG până la 10 MB",
+      "saved": "Salvat",
+      "details": "Detalii",
+      "next": "Continuă"
+    },
+    "editor": {
+      "bold": "Bold",
+      "italic": "Italic",
+      "heading2": "Titlu 2",
+      "heading3": "Titlu 3",
+      "bulletList": "Listă cu puncte",
+      "orderedList": "Listă numerotată",
+      "blockquote": "Citat",
+      "link": "Link",
+      "image": "Inserează imagine",
+      "linkPrompt": "Introdu URL-ul linkului:",
+      "toolbarLabel": "Bara de instrumente a editorului"
+    },
+    "vehicleCategories": {
+      "repair": "Reparație",
+      "service_visit": "Vizită la service",
+      "trip": "Călătorie",
+      "fuel": "Combustibil",
+      "upgrade": "Upgrade",
+      "inspection": "Inspecție",
+      "breakdown": "Defecțiune",
+      "other": "Altele"
+    },
+    "status": {
+      "draft": "Ciornă",
+      "published": "Publicat"
+    },
+    "newEntryOptions": {
+      "personal": "Intrare personală",
+      "vehicle": "Jurnal vehicul"
+    },
+    "noMoreEntries": "Nu mai sunt alte intrări",
+    "notFound": "Intrarea nu a fost găsită.",
+    "backToBlog": "Înapoi la Blog",
+    "writeHeading": {
+      "edit": "Editează intrarea",
+      "new": "Intrare nouă"
+    },
+    "confirmCancel": {
+      "title": "Modificări nesalvate",
+      "body": "Ai modificări nesalvate. Dorești să salvezi înainte de a părăsi pagina?",
+      "discard": "Renunță și părăsește",
+      "keepEditing": "Continuă editarea"
+    },
+    "empty": {
+      "personal": "Nu există intrări încă. Începe să scrii!",
+      "vehicle": "Nu există intrări pentru acest vehicul încă."
+    }
+  },
+  "documents": {
+    "title": "Documente",
+    "subtitle": "Toate documentele vehiculelor tale",
+    "addDocument": "Adaugă document",
+    "loading": "Se încarcă documentele…",
+    "filters": {
+      "allVehicles": "Toate vehiculele",
+      "allTypes": "Toate tipurile de documente",
+      "allStatuses": "Toate statusurile",
+      "search": "Caută documente..."
+    },
+    "columns": {
+      "document": "Document",
+      "vehicle": "Vehicul",
+      "type": "Tip",
+      "validUntil": "Valabil până la",
+      "status": "Status",
+      "actions": "Acțiuni"
+    },
+    "status": {
+      "valid": "Valabil",
+      "expiring": "Expiră curând",
+      "expired": "Expirat",
+      "noExpiry": "Fără expirare"
+    },
+    "types": {
+      "RCA": "Asigurare RCA",
+      "ITP": "Inspecție tehnică periodică (ITP)",
+      "ROV": "Rovinietă",
+      "REGISTRATION": "Certificat de înmatriculare",
+      "ROAD_TAX": "Impozit auto"
+    },
+    "typeAbbr": {
+      "RCA": "RCA",
+      "ITP": "ITP",
+      "ROV": "ROV",
+      "REGISTRATION": "CIV",
+      "ROAD_TAX": "IMP"
+    },
+    "empty": {
+      "noDocuments": "Nu există documente încă. Adaugă primul document.",
+      "noResults": "Niciun document nu corespunde filtrelor."
+    },
+    "footer": {
+      "showing": "Se afișează {{from}}–{{to}} din {{total}} documente",
+      "showingShort": "Se afișează {{count}} din {{total}} documente"
+    },
+    "form": {
+      "editTitle": "Editează documentul",
+      "addTitle": "Adaugă document",
+      "editSubtitle": "Actualizează detaliile documentului mai jos.",
+      "addSubtitle": "Completează detaliile documentului mai jos.",
+      "basicInfo": "Informații de bază",
+      "fields": {
+        "documentType": "Tip document",
+        "provider": "Furnizor",
+        "policyNumber": "Număr poliță",
+        "issueDate": "Data emiterii",
+        "expiryDate": "Data expirării",
+        "policyholder": "Asigurat",
+        "cnpId": "CNP / Serie CI"
+      },
+      "placeholders": {
+        "provider": "ex. Allianz-Țiriac",
+        "policyNumber": "ex. POL-123456789",
+        "policyholder": "ex. Ion Popescu",
+        "cnpId": "ex. 1900101012345"
+      },
+      "selectType": "Selectează tipul",
+      "selectVehicle": "Selectează vehiculul",
+      "errors": {
+        "documentTypeRequired": "Tipul documentului este obligatoriu.",
+        "vehicleRequired": "Vehiculul este obligatoriu."
+      },
+      "statusOptions": {
+        "active": "Activ",
+        "inactive": "Inactiv",
+        "expired": "Expirat"
+      },
+      "validity": "Valabilitate",
+      "noExpirySuffix": "— fără expirare",
+      "noExpiryCheckbox": "Acest document nu are dată de expirare",
+      "documentFile": "Fișier document",
+      "dragDrop": "Trage și plasează",
+      "dragDropHere": "documentul tău aici",
+      "uploadHint": "sau apasă pentru a răsfoi · PDF, JPG, PNG până la 20 MB",
+      "currentFile": "Fișier curent: {{name}}",
+      "analysingDocument": "Se analizează documentul…",
+      "additionalDetails": "Detalii suplimentare",
+      "uploading": "Se încarcă…",
+      "saveChanges": "Salvează modificările",
+      "extraction": {
+        "failedTitle": "Documentul nu a putut fi citit",
+        "notRecognisedTitle": "Tipul documentului nu a fost recunoscut",
+        "highConfidenceTitle": "Câmpuri precompletate din documentul tău",
+        "lowConfidenceTitle": "Câmpuri extrase cu încredere redusă",
+        "failedDesc": "Documentul nu a putut fi analizat. Te rugăm să completezi câmpurile manual.",
+        "notRecognisedDesc": "Nu am putut identifica tipul acestui document. Te rugăm să completezi câmpurile manual.",
+        "highConfidenceDesc": "Verifică valorile precompletate și corectează eventualele erori înainte de a salva.",
+        "lowConfidenceDesc": "Unele valori pot fi inexacte — te rugăm să verifici cu atenție toate câmpurile înainte de a salva."
+      }
+    },
+    "detail": {
+      "documentInfo": "Informații document",
+      "validFrom": "Valabil din",
+      "expiring": "Expiră",
+      "documentFile": "Fișier document",
+      "documentPreview": "Previzualizare document",
+      "document": "Document",
+      "download": "Descarcă",
+      "extractedInfo": "Informații extrase",
+      "extractedInfoNote": "Informații extrase automat din document. Le poți edita dacă este necesar."
+    }
+  },
+  "cars": {
+    "details": {
+      "breadcrumb": {
+        "garage": "Garaj",
+        "formerVehicles": "Vehicule anterioare",
+        "viewDetails": "Vezi detalii"
+      },
+      "archivedOn": "Arhivat la {{date}}",
+      "vehicleDetails": "Detalii vehicul",
+      "vehicleOverview": "Prezentare vehicul",
+      "subtitle": "Profil complet al vehiculului, documente, termene și istoricul mentenanței.",
+      "fields": {
+        "make": "Marcă",
+        "model": "Model",
+        "year": "An",
+        "vin": "VIN",
+        "variant": "Variantă / echipare",
+        "fuelType": "Tip combustibil",
+        "transmission": "Transmisie",
+        "finalMileage": "Kilometraj final",
+        "ownedSince": "Deținut din",
+        "ownershipStartDate": "Data începerii deținerii"
+      },
+      "removeFromArchive": "Scoate din arhivă",
+      "removeFromGarage": "Elimină din garaj",
+      "editVehicle": "Editează vehiculul",
+      "shareVehicle": "Partajează vehiculul",
+      "addMaintenance": "Adaugă mentenanță",
+      "uploadDocument": "Încarcă document",
+      "removeAccess": "Elimină accesul",
+      "sheet": {
+        "shareVehicleDesc": "Invită alte persoane să vadă sau să administreze",
+        "addMaintenanceDesc": "Înregistrează o lucrare de service sau reparație",
+        "uploadDocumentDesc": "Adaugă RCA, ITP sau alte documente",
+        "removeAccessDesc": "Părăsește acest vehicul partajat"
+      },
+      "nextKeyExpiry": "Următoarea expirare importantă",
+      "documentsAndDeadlines": "Documente și termene",
+      "docItem": {
+        "insuranceExpiry": "Data expirării asigurării",
+        "inspectionExpiry": "Data expirării ITP",
+        "vignetteExpiry": "Data expirării rovinietei",
+        "daysLeft": "{{days}} zile rămase"
+      },
+      "maintenanceHistory": {
+        "title": "Istoric reparații și mentenanță",
+        "totalRecords": "Total înregistrări",
+        "totalSpent": "Total cheltuit",
+        "lastService": "Ultimul service",
+        "nextOilService": "Următorul schimb de ulei",
+        "empty": "Nu există înregistrări de mentenanță încă",
+        "table": {
+          "date": "Dată",
+          "mileage": "Kilometraj",
+          "category": "Categorie",
+          "workPerformed": "Lucrare efectuată",
+          "cost": "Cost",
+          "notes": "Note"
+        }
+      },
+      "deleteAlert": {
+        "header": "Ștergi definitiv?",
+        "message": "Toate datele pentru <strong>{{name}}</strong> vor fi șterse definitiv și nu vor putea fi recuperate."
+      }
+    },
+    "form": {
+      "editVehicle": "Editează vehicul",
+      "addVehicle": "Adaugă vehicul",
+      "editSubtitle": "Actualizează detaliile, documentele și fotografiile vehiculului.",
+      "addSubtitle": "Completează detaliile vehiculului pentru a-l adăuga în garaj.",
+      "fields": {
+        "nickname": "Poreclă",
+        "engine": "Motor",
+        "color": "Culoare",
+        "initialMileage": "Kilometraj inițial (km)"
+      },
+      "coreDetailsNote": "Aceste detalii ne ajută să identificăm vehiculul și să personalizăm experiența.",
+      "additionalInfo": {
+        "title": "Informații suplimentare vehicul",
+        "desc": "Variantă, VIN, tip combustibil și altele"
+      },
+      "quickTips": {
+        "title": "Sfaturi rapide",
+        "dismiss": "Închide sfaturile rapide",
+        "tip1": "Adaugă o poreclă pentru a recunoaște ușor vehiculul dintr-o privire.",
+        "tip2": "Încarcă o fotografie pentru ca garajul tău să fie mai personal.",
+        "tip3": "Introdu kilometrajul inițial pentru notificări de service mai precise.",
+        "tip4": "Poți reveni oricând pentru a completa restul informațiilor."
+      },
+      "additionalBadge": {
+        "filled": "{{count}} / {{total}} completate",
+        "empty": "{{total}} câmpuri · opționale"
+      },
+      "documentsBadge": {
+        "set": "Setat",
+        "optional": "Opțional"
+      },
+      "mileageAlert": {
+        "header": "Kilometrajul nu a fost introdus",
+        "message": "Adăugarea kilometrajului curent ne ajută să urmărim mentenanța și să îți oferim notificări precise. Continui fără el?",
+        "addMileage": "Adaugă kilometraj",
+        "continueWithoutIt": "Continuă fără el"
+      },
+      "deleteAlert": {
+        "fallbackName": "acest vehicul"
+      },
+      "mileageHint": {
+        "title": "Kilometrajul inițial este recomandat.",
+        "desc": "Îmbunătățește urmărirea mentenanței, notificările de service și acuratețea rapoartelor. Poți continua și fără el."
+      },
+      "documentsSection": {
+        "desc": "Urmărire schimb ulei — documentele sunt gestionate în secțiunea Documente"
+      },
+      "photos": {
+        "title": "Fotografii",
+        "subtitle": "Adaugă fotografii ale vehiculului. Apasă pe o fotografie pentru a o seta ca implicită. Poți încărca mai multe mai târziu.",
+        "uploadLabel": "Încarcă fotografii",
+        "defaultPhoto": "Fotografie implicită",
+        "setAsDefault": "Apasă pentru a seta ca implicită",
+        "defaultBadge": "Implicită",
+        "limitReached": "Limita de {{max}} fotografii a fost atinsă. Elimină o fotografie pentru a adăuga altele."
+      },
+      "actionBar": {
+        "saving": "Se salvează...",
+        "adding": "Se adaugă...",
+        "update": "Actualizează vehiculul",
+        "save": "Salvează vehiculul",
+        "saveAndAddAnother": "Salvează și adaugă altul"
+      }
+    },
+    "shareVehicle": {
+      "subtitle": "Gestionează cine are acces la {{name}}",
+      "inviteUser": "Invită utilizator",
+      "emailAddress": "Adresă de email",
+      "sending": "Se trimite…",
+      "sendInvite": "Trimite invitația",
+      "inviteError": "Invitația nu a putut fi trimisă.",
+      "peopleWithAccess": "Persoane cu acces",
+      "pending": "În așteptare",
+      "roles": {
+        "owner": "Proprietar",
+        "full": "Complet",
+        "user": "Utilizator",
+        "maintenance": "Mentenanță",
+        "viewer": "Vizualizator"
+      }
+    },
+    "removePanel": {
+      "titleSold": "Gestionează vehiculul arhivat",
+      "titleActive": "Elimină din garaj",
+      "subtitle": "Ce vrei să faci cu <strong>{{name}}</strong>?",
+      "restore": {
+        "title": "Adaugă înapoi în garaj",
+        "desc": "Restaurează ca vehicul activ. Tot istoricul este păstrat."
+      },
+      "markSold": {
+        "title": "Marchează ca vândut",
+        "desc": "Arhivat în Vehicule anterioare. Tot istoricul este păstrat, doar pentru citire."
+      },
+      "deletePermanently": {
+        "title": "Șterge definitiv",
+        "desc": "Toate datele vor fi șterse. Această acțiune nu poate fi anulată."
+      }
+    },
+    "list": {
+      "cardsView": "Vizualizare carduri",
+      "listView": "Vizualizare listă",
+      "cards": "Carduri",
+      "list": "Listă",
+      "loading": "Se încarcă mașinile…",
+      "sharedWithMe": "Partajate cu mine",
+      "formerVehicles": "Vehicule anterioare",
+      "sold": "Vândut",
+      "empty": {
+        "title": "Garajul tău este gol",
+        "description": "Adaugă primul vehicul pentru a începe să urmărești documentele, mentenanța și termenele importante.",
+        "addFirst": "Adaugă primul vehicul",
+        "howItWorks": "Cum funcționează",
+        "hint": "Poți adăuga oricând mai multe vehicule.",
+        "gettingStarted": {
+          "title": "Primii pași",
+          "step1Title": "Adaugă detaliile vehiculului",
+          "step1Desc": "Informații de bază precum marca, modelul și anul",
+          "step2Title": "Încarcă certificatul și asigurarea",
+          "step2Desc": "Le vom păstra în siguranță și organizate",
+          "step3Title": "Setează datele de service și inspecție",
+          "step3Desc": "Primești notificări înainte de termen"
+        },
+        "unlock": {
+          "title": "Ce deblochezi",
+          "docsTitle": "Notificări pentru documente",
+          "docsDesc": "Nu mai ratezi nicio expirare",
+          "serviceTitle": "Istoric service",
+          "serviceDesc": "Urmărești toată mentenanța într-un singur loc",
+          "deadlinesTitle": "Termene apropiate",
+          "deadlinesDesc": "Ești mereu pregătit pentru sarcinile importante"
+        },
+        "tip": {
+          "label": "Sfat:",
+          "text": "Începe cu mașina pe care o folosești cel mai des și adaugă restul mai târziu.",
+          "subtext": "Tu deții controlul."
+        }
+      }
+    },
+    "toast": {
+      "createSuccess": "Mașina a fost adăugată cu succes!",
+      "updateSuccess": "Mașina a fost actualizată cu succes!",
+      "deleteSuccess": "Mașina a fost ștearsă cu succes!",
+      "markSoldSuccess": "Mașina a fost marcată ca vândută.",
+      "restoreSuccess": "Mașina a fost restaurată în garaj.",
+      "genericError": "A apărut o eroare. Încearcă din nou."
+    }
+  },
+  "car": {
+    "viewDetails": "Vezi detalii",
+    "licensePlate": "Număr de înmatriculare",
+    "fields": {
+      "oilService": "Schimb ulei",
+      "lastOilService": "Ultimul schimb de ulei",
+      "lastOilServiceDate": "Data ultimului schimb de ulei",
+      "lastOilServiceMileage": "Kilometraj la ultimul schimb de ulei",
+      "ownershipSince": "Deținut din",
+      "initialMileage": "Kilometraj inițial",
+      "currentMileage": "Kilometraj curent"
+    },
+    "documents": {
+      "item": {
+        "insurance": "Asigurare",
+        "issueDate": "Data emiterii",
+        "expiryDate": "Data expirării"
+      },
+      "insurance": {
+        "label": "RCA",
+        "tooltip": "RCA — Asigurare de răspundere civilă auto",
+        "expires": "Expiră în {{days}} zile"
+      },
+      "technicalInspection": {
+        "label": "ITP",
+        "tooltip": "Inspecție tehnică periodică (ITP)",
+        "expires": "Expiră în {{days}} zile"
+      },
+      "vignette": {
+        "label": "Rovinietă",
+        "tooltip": "Rovinietă / taxă de drum",
+        "expires": "Expiră în {{days}} zile"
+      }
+    }
+  },
+  "shared": {
+    "photoCarousel": {
+      "main": "Principală",
+      "tapOutsideOr": "Apasă în afară sau apasă"
+    },
+    "formField": {
+      "uploading": "Se încarcă…",
+      "onlyImagesAllowed": "Sunt permise doar fișiere imagine!",
+      "fileSizeLimit": "Dimensiunea fișierului trebuie să fie mai mică de 1MB"
+    },
+    "vehicleCatalogSelect": {
+      "make": "Marcă",
+      "model": "Model",
+      "year": "An",
+      "noMakesFound": "Nu s-au găsit mărci",
+      "noModelsFound": "Nu s-au găsit modele",
+      "noYearsFound": "Nu s-au găsit ani",
+      "selectMakeFirst": "Selectează mai întâi marca"
+    }
+  },
+  "login": {
+    "trustBadge": "De încredere pentru proprietarii de vehicule",
+    "headline": "Administrează-ți vehiculele<br>cu încredere",
+    "heroDesc": "Urmărește documentele, întreținerea și termenele importante, astfel încât vehiculele tale să rămână mereu pregătite de drum și fără griji.",
+    "card": {
+      "title": "Bine ai revenit",
+      "subtitle": "Conectează-te în siguranță cu contul tău Google",
+      "googleButton": "Continuă cu Google",
+      "or": "sau",
+      "privacyLine": "Sigur, privat și ușor de utilizat.",
+      "privacyLineMuted": "Nu accesăm și nu distribuim niciodată datele tale Google."
+    },
+    "features": {
+      "privacy": {
+        "title": "Datele tale rămân private",
+        "desc": "Îți respectăm confidențialitatea și îți păstrăm datele în siguranță."
+      },
+      "security": {
+        "title": "Securitate la cele mai înalte standarde",
+        "desc": "Securitate de nivel enterprise pentru a proteja ce contează cu adevărat."
+      },
+      "oneAccount": {
+        "title": "Un singur cont pentru toate vehiculele",
+        "desc": "Accesează toate vehiculele și datele tale într-un singur loc."
+      }
+    },
+    "footer": {
+      "copyright": "© 2026 History Auto Utility. Toate drepturile rezervate.",
+      "privacyPolicy": "Politica de confidențialitate",
+      "termsOfService": "Termeni și condiții"
+    },
+    "preview": {
+      "vehiclesCount": "3 vehicule",
+      "documentsExpireSoon": "2 documente expiră curând",
+      "oilServiceIn": "Schimb de ulei în <strong>1.250 km</strong>",
+      "stats": {
+        "documentsExpiring": "Documente care expiră"
+      },
+      "documentsUpdated": "Documente actualizate",
+      "insuranceDocument": "Document de asigurare",
+      "todayAt": "Astăzi, 10:24"
+    }
+  },
+  "maintenance": {
+    "title": "Întreținere",
+    "subtitle": "Urmărește istoricul service-urilor, sarcinile viitoare și îngrijirea vehiculului.",
+    "toast": {
+      "createSuccess": "Înregistrarea a fost adăugată cu succes!",
+      "createError": "Eroare la adăugarea înregistrării. Încearcă din nou."
+    },
+    "stats": {
+      "lastOilChange": "Ultimul schimb de ulei",
+      "at": "la {{ value }}",
+      "totalRecords": "Total înregistrări",
+      "entries": "înregistrări de întreținere",
+      "nextService": "Următorul service",
+      "inDays": "Peste {{ days }} zile",
+      "estimated": "Est. {{ date }}"
+    },
+    "tabs": {
+      "all": "Toate",
+      "upcoming": "Viitoare",
+      "history": "Istoric"
+    },
+    "empty": {
+      "noRecords": "Nu există înregistrări încă",
+      "noRecordsDesc": "Adaugă prima înregistrare de întreținere pentru {{ name }}.",
+      "noFilterMatch": "Nicio înregistrare nu corespunde acestui filtru",
+      "noRecordsShort": "Nicio înregistrare",
+      "noVehicle": "Niciun vehicul adăugat",
+      "noVehicleDesc": "Adaugă mai întâi un vehicul din secțiunea Garaj."
+    },
+    "reminders": {
+      "title": "Mementouri viitoare",
+      "viewAll": "Vezi toate",
+      "dueIn": "Scadent în <strong>{{ value }}</strong>"
+    },
+    "recordsCard": {
+      "upcoming": "Viitoare",
+      "history": "Istoric întreținere",
+      "recent": "Întreținere recentă"
+    },
+    "table": {
+      "serviceItem": "Service / Piesă",
+      "date": "Dată",
+      "mileage": "Kilometraj",
+      "cost": "Cost",
+      "notes": "Notițe"
+    },
+    "sidebar": {
+      "categories": "Categorii de service",
+      "tip": "Sfat: Menține întreținerea la zi pentru performanțe optime și o valoare de revânzare mai bună."
+    },
+    "priority": {
+      "expired": "Expirat",
+      "urgent": "Urgent",
+      "medium": "Mediu"
+    },
+    "daysLeft": {
+      "expired": "Expirat",
+      "oneDay": "1 zi",
+      "days": "{{ count }} zile"
+    },
+    "categories": {
+      "oilChange": "Ulei",
+      "brakeService": "Frâne",
+      "tireService": "Anvelope",
+      "fluidService": "Fluide",
+      "engineService": "Motor",
+      "inspection": "Inspecție",
+      "batteryService": "Baterie",
+      "filterService": "Filtre",
+      "lightService": "Lumini",
+      "transmissionService": "Transmisie",
+      "other": "Altele"
+    },
+    "form": {
+      "title": "Adaugă întreținere",
+      "subtitle": "Înregistrează un service sau o reparație",
+      "fields": {
+        "vehicle": "Vehicul",
+        "serviceDate": "Data service-ului",
+        "mileage": "Kilometraj",
+        "category": "Categorie",
+        "type": "Tip",
+        "description": "Descriere / Piese",
+        "cost": "Cost (RON)",
+        "expiryDate": "Dată expirare / memento"
+      },
+      "placeholders": {
+        "mileage": "ex. 51000",
+        "description": "ex. ulei 10W40, filtru de aer MANN, filtru de ulei",
+        "cost": "ex. 250"
+      },
+      "serviceTypes": {
+        "maintenance": "Întreținere",
+        "repair": "Reparație",
+        "improvement": "Îmbunătățire"
+      }
+    }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -63,8 +63,10 @@ void bootstrapApplication(AppComponent, {
     },
     provideTransloco({
       config: {
-        availableLangs: ['en'],
+        availableLangs: ['en', 'ro'],
         defaultLang: 'en',
+        fallbackLang: 'en',
+        reRenderOnLangChange: true,
         prodMode: !isDevMode(),
       },
       loader: TranslocoHttpLoader,


### PR DESCRIPTION
Wires every visible string across the app (cars, documents, maintenance, blog, login, shared components, alerts/toasts) to the en/ro i18n files instead of inline literals, and brings ro.json fully in sync with en.json (516 matching keys). Also consolidates duplicate translation keys that represented the same concept (login preview mirrors overview/sidebar, generic actions like edit/delete/cancel reuse common.*) for a leaner, more consistent translation structure.